### PR TITLE
Show header on legacy /situation page

### DIFF
--- a/client/policyengine-core/package.json
+++ b/client/policyengine-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "policyengine-core",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "React component library for PolicyEngine",
   "author": "nikhilwoodruff",
   "license": "MIT",

--- a/client/policyengine-core/src/common/layout.jsx
+++ b/client/policyengine-core/src/common/layout.jsx
@@ -128,6 +128,9 @@ export function Header(props) {
 					<Route path="/household">
 						<MainNavigation country={props.country} policy={props.policy} household={props.household} selected="household" />
 					</Route>
+					<Route path="/situation">
+						<MainNavigation country={props.country} policy={props.policy} household={props.household} selected="household" />
+					</Route>
 					<Route path="/household-impact">
 						<MainNavigation country={props.country} policy={props.policy} household={props.household} selected="household-impact" />
 					</Route>


### PR DESCRIPTION
Ensures both /household and /situation (legacy) point to the household input page (Resilience UBI calculator relies on this at the moment)