### PR TITLE
Fix assorted issues

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -4,3 +4,4 @@
     - Parameter scale components now included in `get_descendants()`.
     fixed:
     - Folder paths in `Dataset`s are parsed as `Path`s.
+    - Empty `input:` fields are parsed as `{}`.

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,6 @@
+- bump: minor
+  changes:
+    changed:
+    - Parameter scale components now included in `get_descendants()`.
+    fixed:
+    - Folder paths in `Dataset`s are parsed as `Path`s.

--- a/policyengine_core/data/dataset.py
+++ b/policyengine_core/data/dataset.py
@@ -37,6 +37,8 @@ class Dataset:
             raise ValueError(
                 "Dataset folder_path must be specified in the dataset class definition."
             )
+        elif isinstance(self.folder_path, str):
+            self.folder_path = Path(self.folder_path)
 
         if not self.folder_path.exists():
             logging.info(

--- a/policyengine_core/parameters/parameter_scale.py
+++ b/policyengine_core/parameters/parameter_scale.py
@@ -72,7 +72,8 @@ class ParameterScale(AtInstantLike):
         )
 
     def get_descendants(self) -> Iterable:
-        return iter(())
+        for bracket in self.brackets:
+            yield from bracket.get_descendants()
 
     def clone(self) -> "ParameterScale":
         clone = commons.empty_clone(self)

--- a/policyengine_core/parameters/parameter_scale_bracket.py
+++ b/policyengine_core/parameters/parameter_scale_bracket.py
@@ -1,4 +1,5 @@
-from policyengine_core.parameters import ParameterNode
+from typing import Iterable
+from policyengine_core.parameters import Parameter, ParameterNode
 
 
 class ParameterScaleBracket(ParameterNode):
@@ -9,3 +10,8 @@ class ParameterScaleBracket(ParameterNode):
     _allowed_keys = set(
         ["amount", "threshold", "rate", "average_rate", "base"]
     )
+
+    def get_descendants(self) -> Iterable[Parameter]:
+        for key in self._allowed_keys:
+            if key in self.children:
+                yield self.children[key]

--- a/policyengine_core/taxbenefitsystems/tax_benefit_system.py
+++ b/policyengine_core/taxbenefitsystems/tax_benefit_system.py
@@ -12,6 +12,7 @@ import typing
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     Dict,
     List,
     Optional,
@@ -553,3 +554,26 @@ class TaxBenefitSystem:
         )  # Import here to avoid circular dependency.
 
         run_tests(self, paths, options=dict(verbose=verbose))
+    
+
+
+    def modify_parameters(
+        self, modifier_function: Callable[[ParameterNode], ParameterNode]
+    ) -> None:
+        """Make modifications on the parameters of the legislation.
+
+        Call this function in `apply()` if the reform asks for legislation parameter modifications.
+
+        Args:
+            modifier_function: A function that takes a :obj:`.ParameterNode` and should return an object of the same type.
+        """
+        reform_parameters = modifier_function(self.parameters)
+        if not isinstance(reform_parameters, ParameterNode):
+            return ValueError(
+                "modifier_function {} in module {} must return a ParameterNode".format(
+                    modifier_function.__name__,
+                    modifier_function.__module__,
+                )
+            )
+        self.parameters = reform_parameters
+        self._parameters_at_instant_cache = {}

--- a/policyengine_core/taxbenefitsystems/tax_benefit_system.py
+++ b/policyengine_core/taxbenefitsystems/tax_benefit_system.py
@@ -554,8 +554,6 @@ class TaxBenefitSystem:
         )  # Import here to avoid circular dependency.
 
         run_tests(self, paths, options=dict(verbose=verbose))
-    
-
 
     def modify_parameters(
         self, modifier_function: Callable[[ParameterNode], ParameterNode]

--- a/policyengine_core/tools/test_runner.py
+++ b/policyengine_core/tools/test_runner.py
@@ -184,6 +184,8 @@ class YamlItem(pytest.Item):
 
         builder = SimulationBuilder()
         unsafe_input = self.test.get("input", {})
+        if unsafe_input is None:
+            unsafe_input = {}
         period = self.test.get("period")
         input = {}
         inline_reforms = []


### PR DESCRIPTION
### Changed

- Parameter scale components now included in `get_descendants()`.

### Fixed

- Folder paths in `Dataset`s are parsed as `Path`s. (Fixes #30)
- Empty `input:` fields are parsed as `{}`. (Fixes #29)
