### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    removed:
+      - Python 3.6 stated support.

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ setup(
         "License :: OSI Approved :: GNU Affero General Public License v3",
         "Operating System :: POSIX",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
Fixes PolicyEngine/policyengine-core#34

We're not really supporting anything but 3.9 right now (it's the only one in the test suite) but this will at least remove suggestions that we support 3.6.