### PR TITLE
Add changelog entry instructions to our contributing documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+docs/contributing/intro.md

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Added documentation on populating changelog entries. Also created a CONTRIBUTING.md symlink to make contributing guidelines easier to find.

--- a/docs/contributing/intro.md
+++ b/docs/contributing/intro.md
@@ -7,6 +7,20 @@ Any and all contributions are welcome to this project. You can help by:
 
 If you file an issue or a pull request, one of the maintainers (primarily @nikhilwoodruff) will respond to it within at least a week. If you don't hear back, feel free to ping us on the issue or pull request.
 
+## Changelog Entries
+
+Before you send out a pull request, make sure to add a description of your changes to [changelog_entry.yaml](../../changelog_entry.yaml).
+For example,
+```yaml
+- bump: patch
+  changes:
+    fixed:
+    - Fixed a bug causing Windows tests to fail.
+```
+You can find more examples in [changelog.yaml](../../changelog.yaml). Note that you do not need to add the date field.
+That field is automatically populated by `make changelog`. Also, note that **you should not run `make changelog` 
+yourself**, as [our GitHub workflows](../../.github/workflows) will do this for you as part of the build process.
+
 ## Pull requests
 
 Each pull request should:


### PR DESCRIPTION
- [x] `make format && make documentation` has been run.

## What's changed

- I added instructions on how to write changeling entries to our contributing documentation.
- I also added a CONTRIBUTING.md symlink to docs/contributing/intro.md, to make it easier for first-time contributors to find.