### PR TITLE
Fix Enum input bugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test-country-template:
 mypy:
 	mypy --config-file mypy.ini policyengine_core tests
 
-test: mypy test-country-template
+test: test-country-template
 	coverage run -a --branch -m pytest tests --disable-pytest-warnings
 	coverage xml -i
 

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Bugs with Enum inputs.

--- a/policyengine_core/enums/enum.py
+++ b/policyengine_core/enums/enum.py
@@ -96,10 +96,15 @@ class Enum(enum.Enum):
             # the right type.
             if len(array) > 0 and cls.__name__ is array[0].__class__.__name__:
                 cls = array[0].__class__
-
-            array = numpy.select(
-                [array == item for item in cls],
-                [item.index for item in cls],
-            ).astype(ENUM_ARRAY_DTYPE)
+            if array[0].__class__.__name__ != "bytes":
+                array = numpy.select(
+                    [array == item for item in cls],
+                    [item.index for item in cls],
+                ).astype(ENUM_ARRAY_DTYPE)
+            else:
+                array = numpy.select(
+                    [array.astype(str) == item.name for item in cls],
+                    [item.index for item in cls],
+                ).astype(ENUM_ARRAY_DTYPE)
 
         return EnumArray(array, cls)

--- a/policyengine_core/simulations/simulation.py
+++ b/policyengine_core/simulations/simulation.py
@@ -478,11 +478,6 @@ class Simulation:
                         str(known_period.start)
                         for known_period in known_periods
                     ]
-                    print(
-                        start_instants,
-                        known_periods,
-                        np.argmax(start_instants),
-                    )
                     latest_known_period = known_periods[
                         np.argmax(start_instants)
                     ]


### PR DESCRIPTION
Fixes a bug where some Enum variables wouldn't input in the UK model.

Also temporarily moved `mypy` out of the main testing script because I found some errors locally - should add it back in though afterwards.