### PR TITLE
Add code style black badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,6 @@
 
 [![codecov](https://codecov.io/gh/PolicyEngine/policyengine-core/branch/master/graph/badge.svg?token=BLoCjCf5Qr)](https://codecov.io/gh/PolicyEngine/policyengine-core)
 [![PyPI version](https://badge.fury.io/py/policyengine-core.svg)](https://badge.fury.io/py/policyengine-core)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 This package, a fork of [OpenFisca-Core](https://github.com/OpenFisca/OpenFisca-Core), powers PolicyEngine country models and apps.

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    added:
+      - Added black code style badge


### PR DESCRIPTION
- [x] `make format && make documentation` has been run.

## What's changed

I added a badge displaying that this repo uses the black code style. I think this will make it more appealing to devs looking to contribute because black is a very common style.