### PR TITLE
Remove `aggr`

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    removed:
+      - `aggr` function, which is superseded by `add`.

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
 - bump: patch
   changes:
     removed:
-      - `aggr` function, which is superseded by `add`.
+      - aggr function, which is superseded by add.

--- a/policyengine_core/commons/formulas.py
+++ b/policyengine_core/commons/formulas.py
@@ -227,31 +227,6 @@ def add(
     )
 
 
-def aggr(entity, period, variables, options=None):
-    """Sums a list of variables belonging to entity members.
-
-    Args:
-        entity (Population): The entity population, as passed in formulas.
-        period (Period): The period, as pass in formulas.
-        variables (List[str]): A list of variable names.
-        options (List[str], optional): Options to pass to the `entity(variable, period)` call. Defaults to None.
-
-    Raises:
-        ValueError: If any target variable is not below the target entity level.
-
-    Returns:
-        ArrayLike: The result of the operation.
-    """
-    return for_each_variable(
-        entity,
-        period,
-        variables,
-        agg_func="add",
-        group_agg_func="add",
-        options=options,
-    )
-
-
 def and_(
     entity: Population,
     period: Period,


### PR DESCRIPTION
Fixes #77

Each country model (US, UK, CA) has a PR that removes all instances of `aggr`.