### PR TITLE
Fix axes bug

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Bug causing simulations containing multiple group entities and axes to fail to simulate.

--- a/policyengine_core/simulations/simulation_builder.py
+++ b/policyengine_core/simulations/simulation_builder.py
@@ -704,8 +704,9 @@ class SimulationBuilder:
             )
             # Adjust ids
             original_ids = self.get_ids(entity_name) * cell_count
-            indices = np.arange(
-                0, cell_count * self.entity_counts[entity_name]
+            # indices should be [0, 0, 0, 1, 1, 1, 2, 2, 2, ...] where each number is repeated axis_entity_count times
+            indices = np.repeat(
+                np.arange(0, cell_count), self.entity_counts[entity_name]
             )
             adjusted_ids = [
                 id + str(ix) for id, ix in zip(original_ids, indices)
@@ -718,7 +719,8 @@ class SimulationBuilder:
             # Adjust memberships, for group entities only
             if entity_name != self.persons_plural:
                 original_memberships = self.get_memberships(entity_name)
-                repeated_memberships = np.repeat(
+                # repeat membership, e.g. [1, 0] -> [1, 0, 1, 0, ...]
+                repeated_memberships = np.tile(
                     original_memberships, cell_count
                 )
                 indices = (

--- a/tests/core/test_axes.py
+++ b/tests/core/test_axes.py
@@ -147,9 +147,9 @@ def test_add_axis_with_group(persons):
     assert simulation_builder.get_count("persons") == 4
     assert simulation_builder.get_ids("persons") == [
         "Alicia0",
+        "Javier0",
+        "Alicia1",
         "Javier1",
-        "Alicia2",
-        "Javier3",
     ]
     assert simulation_builder.get_input("salary", "2018-11") == pytest.approx(
         [0, 0, 3000, 3000]
@@ -207,9 +207,9 @@ def test_add_axis_on_households(persons, households):
     assert simulation_builder.get_count("households") == 4
     assert simulation_builder.get_ids("households") == [
         "housea0",
+        "houseb0",
+        "housea1",
         "houseb1",
-        "housea2",
-        "houseb3",
     ]
     assert simulation_builder.get_input("rent", "2018-11") == pytest.approx(
         [0, 0, 3000, 0]


### PR DESCRIPTION
Simulations which had both of the following would fail to simulate:
* Axes
* Multiple group entities

This turned out to be an issue with the way that Core expands the axes. I found a few low-level causes (np.tile needed but np.repeat was used), but I also changed the naming schedule for the expanded entities, from: 

(marital_unit, second_marital_unit) -> (marital_unit0, second_marital_unit1, marital_unit2, second_marital_unit3)

to:

(marital_unit, second_marital_unit) -> (marital_unit0, second_marital_unit0, marital_unit1, second_marital_unit1)

which I thought made more sense (the number at the end signifies the iteration, rather than the entity number).

cc @MaxGhenis 