### PR TITLE
Fixed deprecated pytest code and a GitHub action bug

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -82,7 +82,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Publish a git tag
         run: ".github/publish-git-tag.sh || true"
       - name: Install package

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Fixed pytest deprecated usages since version 7, and fixed a bug that prevented new package from publishing.

--- a/policyengine_core/tools/test_runner.py
+++ b/policyengine_core/tools/test_runner.py
@@ -110,19 +110,19 @@ def run_tests(tax_benefit_system, paths, options=None):
 
 
 class YamlFile(pytest.File):
-    def __init__(self, path, fspath, parent, tax_benefit_system, options):
-        super(YamlFile, self).__init__(path, parent)
+    def __init__(self, *, tax_benefit_system, options, **kwargs):
+        super(YamlFile, self).__init__(**kwargs)
         self.tax_benefit_system = tax_benefit_system
         self.options = options
 
     def collect(self):
         try:
-            tests = yaml.load(self.fspath.open(), Loader=Loader)
+            tests = yaml.load(self.path.open(), Loader=Loader)
         except (yaml.scanner.ScannerError, yaml.parser.ParserError, TypeError):
             message = os.linesep.join(
                 [
                     traceback.format_exc(),
-                    f"'{self.fspath}' is not a valid YAML file. Check the stack trace above for more details.",
+                    f"'{self.path}' is not a valid YAML file. Check the stack trace above for more details.",
                 ]
             )
             raise ValueError(message)
@@ -156,9 +156,9 @@ class YamlItem(pytest.Item):
     """
 
     def __init__(
-        self, name, parent, baseline_tax_benefit_system, test, options
+        self, *, baseline_tax_benefit_system, test, options, **kwargs
     ):
-        super(YamlItem, self).__init__(name, parent)
+        super(YamlItem, self).__init__(**kwargs)
         self.baseline_tax_benefit_system = baseline_tax_benefit_system
         self.options = options
         self.test = test
@@ -378,16 +378,15 @@ class OpenFiscaPlugin(object):
         self.tax_benefit_system = tax_benefit_system
         self.options = options
 
-    def pytest_collect_file(self, parent, path):
+    def pytest_collect_file(self, parent, file_path):
         """
         Called by pytest for all plugins.
         :return: The collector for test methods.
         """
-        if path.ext in [".yaml", ".yml"]:
+        if file_path.suffix in [".yaml", ".yml"]:
             return YamlFile.from_parent(
                 parent,
-                path=path,
-                fspath=path,
+                path=file_path,
                 tax_benefit_system=self.tax_benefit_system,
                 options=self.options,
             )

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Scientific/Engineering :: Information Analysis",
     ],
     description="Core microsimulation engine enabling country-specific policy models.",

--- a/tests/core/tools/test_runner/test_yaml_runner.py
+++ b/tests/core/tools/test_runner/test_yaml_runner.py
@@ -80,7 +80,7 @@ class TestItem(YamlItem):
             parent=TestFile.from_parent(None),
             baseline_tax_benefit_system=TaxBenefitSystem(),
             test=test,
-            options={}
+            options={},
         )
 
         self.tax_benefit_system = self.baseline_tax_benefit_system

--- a/tests/core/tools/test_runner/test_yaml_runner.py
+++ b/tests/core/tools/test_runner/test_yaml_runner.py
@@ -76,7 +76,11 @@ class TestFile(YamlFile):
 class TestItem(YamlItem):
     def __init__(self, parent=None, test=None):
         super().__init__(
-            "", TestFile.from_parent(None), TaxBenefitSystem(), test, {}
+            name="",
+            parent=TestFile.from_parent(None),
+            baseline_tax_benefit_system=TaxBenefitSystem(),
+            test=test,
+            options={}
         )
 
         self.tax_benefit_system = self.baseline_tax_benefit_system


### PR DESCRIPTION
fixes #18, fixes #32 

Python 3.10 support was already added by @nikhilwoodruff, so the primary purpose of this PR is to address any remaining pytest code in the package that is already deprecated but hasn't been removed yet.

`OpenFiscaPlugin`'s `pytest_collect_file(self, parent, path)`'s `path` has been changed to `file_path`, according to https://docs.pytest.org/en/stable/deprecations.html#py-path-local-arguments-for-hooks-replaced-with-pathlib-path.

For `YamlFile` and `YamlItem`, their constructors have been changed to accept `**kwargs` instead, according to https://docs.pytest.org/en/stable/deprecations.html#constructors-of-custom-pytest-node-subclasses-should-take-kwargs; and all `self.fspath` references within the methods have been changed to `self.path`, according to https://docs.pytest.org/en/stable/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path.

Because of the constructor change in `YamlFile` and `YamlItem`, the test class `TestItem`'s way of invoking `super()` has also been changed.

Last but not least, this PR addresses the failure of GitHub action "publish" by simply quoting the value of "python-version" to make sure the action would read the correct version number.

Please let me know if you have any concerns about this PR. Thank you!
