### PR TITLE
Fix unhelpful error message

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    fixed:
+    - Bug causing unhelpful errors when variables are not found.

--- a/policyengine_core/taxbenefitsystems/tax_benefit_system.py
+++ b/policyengine_core/taxbenefitsystems/tax_benefit_system.py
@@ -598,12 +598,16 @@ class TaxBenefitSystem:
         location = (
             inspect.getsourcefile(module).split(package_name)[0].rstrip("/")
         )
-
-        home_page_metadatas = [
-            metadata.split(":", 1)[1].strip(" ")
-            for metadata in distribution._get_metadata(distribution.PKG_INFO)
-            if "Home-page" in metadata
-        ]
+        try:
+            home_page_metadatas = [
+                metadata.split(":", 1)[1].strip(" ")
+                for metadata in distribution._get_metadata(
+                    distribution.PKG_INFO
+                )
+                if "Home-page" in metadata
+            ]
+        except:
+            home_page_metadatas = None
         repository_url = home_page_metadatas[0] if home_page_metadatas else ""
         return {
             "name": distribution.key,


### PR DESCRIPTION
This error has appeared a few places recently:

> 'PathDistribution' object has no attribute '_get_metadata'

I wasn't able to reproduce it locally, but this PR adds a catch for it.

cc @MaxGhenis @leogoldman