### PR TITLE
Fix bug in automatic period adjustment feature

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Fix bug affecting microsimulation runs in countries which use automatic period adjustments.

--- a/policyengine_core/simulations/simulation.py
+++ b/policyengine_core/simulations/simulation.py
@@ -474,12 +474,12 @@ class Simulation:
         if variable.definition_period == MONTH and period.unit == YEAR:
             if variable.quantity_type == QuantityType.STOCK:
                 contained_months = period.get_subperiods(MONTH)
-                return self.calculate(variable_name, contained_months[-1])
+                return self._calculate(variable_name, contained_months[-1])
             else:
                 return self.calculate_add(variable_name, period)
         elif variable.definition_period == YEAR and period.unit == MONTH:
             if variable.quantity_type == QuantityType.STOCK:
-                return self.calculate(variable_name, period.this_year)
+                return self._calculate(variable_name, period.this_year)
             else:
                 return self.calculate_divide(variable_name, period)
 


### PR DESCRIPTION
Needed this bugfix to get the US microsim working- essentially, #119 used weighted arrays unintentionally within the internal microsim model, rather than just adding them at the end, which caused the Core logic to fail to index properly and throw an error.