### PR TITLE
Add method for propagating units to descendants for `ParameterScale` objects

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    changed:
+    - Add method for propagating units to descendants for ParameterScale objects

--- a/policyengine_core/parameters/parameter_scale.py
+++ b/policyengine_core/parameters/parameter_scale.py
@@ -72,15 +72,20 @@ class ParameterScale(AtInstantLike):
         )
 
     def propagate_units(self) -> None:
-        for unit_key in parameters.ParameterScaleBracket.allowed_unit_keys():
-            if unit_key in self.metadata:
-                child_key = unit_key[:-5]
-                for bracket in self.brackets:
-                    if child_key in bracket.children:
-                        if "unit" not in bracket.children[child_key].metadata:
-                            bracket.children[child_key].metadata["unit"] = (
-                                self.metadata[unit_key]
-                            )
+        unit_keys = filter(
+            lambda k: k in self.metadata,
+            parameters.ParameterScaleBracket.allowed_unit_keys(),
+        )
+        for unit_key in unit_keys:
+            child_key = unit_key[:-5]
+            for bracket in self.brackets:
+                if (
+                    child_key in bracket.children
+                    and "unit" not in bracket.children[child_key].metadata
+                ):
+                    bracket.children[child_key].metadata["unit"] = (
+                        self.metadata[unit_key]
+                    )
 
     def get_descendants(self) -> Iterable:
         for bracket in self.brackets:

--- a/policyengine_core/parameters/parameter_scale.py
+++ b/policyengine_core/parameters/parameter_scale.py
@@ -71,6 +71,17 @@ class ParameterScale(AtInstantLike):
             ]
         )
 
+    def propagate_units(self) -> None:
+        for unit_key in parameters.ParameterScaleBracket.allowed_unit_keys():
+            if unit_key in self.metadata:
+                child_key = unit_key[:-5]
+                for bracket in self.brackets:
+                    if child_key in bracket.children:
+                        if "unit" not in bracket.children[child_key].metadata:
+                            bracket.children[child_key].metadata["unit"] = (
+                                self.metadata[unit_key]
+                            )
+
     def get_descendants(self) -> Iterable:
         for bracket in self.brackets:
             yield bracket

--- a/policyengine_core/parameters/parameter_scale_bracket.py
+++ b/policyengine_core/parameters/parameter_scale_bracket.py
@@ -11,6 +11,10 @@ class ParameterScaleBracket(ParameterNode):
         ["amount", "threshold", "rate", "average_rate", "base"]
     )
 
+    @staticmethod
+    def allowed_unit_keys():
+        return [key + "_unit" for key in ParameterScaleBracket._allowed_keys]
+
     def get_descendants(self) -> Iterable[Parameter]:
         for key in self._allowed_keys:
             if key in self.children:

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ dev_requirements = [
     "coverage",
     "furo",
     "mypy==0.991",
-    "sphinx==4.5.0",
+    "sphinx==5.0.0",
     "sphinx-argparse==0.4.0",
     "sphinx-math-dollar==1.2.1",
     "types-PyYAML==6.0.12.2",

--- a/tests/core/parameter_validation/parameter_for_unit_propagation.yaml
+++ b/tests/core/parameter_validation/parameter_for_unit_propagation.yaml
@@ -33,7 +33,7 @@ brackets:
         2023-01-01: 21_560
         2024-01-01: 22_720
       metadata:
-        a: b
+        unit: US dollars
   - threshold:
       values:
         1995-01-01: 2

--- a/tests/core/parameter_validation/parameter_for_unit_propagation.yaml
+++ b/tests/core/parameter_validation/parameter_for_unit_propagation.yaml
@@ -3,6 +3,7 @@ metadata:
   type: single_amount
   threshold_unit: child
   amount_unit: currency-USD
+  rate_unit: /1
   label: Test unit propagation
 
 brackets:

--- a/tests/core/parameter_validation/parameter_for_unit_propagation.yaml
+++ b/tests/core/parameter_validation/parameter_for_unit_propagation.yaml
@@ -1,0 +1,68 @@
+description: Propagate units in metadata of a scaled parameter to its descendants
+metadata:
+  type: single_amount
+  threshold_unit: child
+  amount_unit: currency-USD
+  label: Test unit propagation
+
+brackets:
+  - threshold:
+      values:
+        1995-01-01: 0
+    amount:
+      values:
+        2017-01-01: 8_340
+        2018-01-01: 8_510
+        2019-01-01: 8_650
+        2020-01-01: 8_790
+        2021-01-01: 11_610
+        2022-01-01: 9_160
+        2023-01-01: 9_800
+        2024-01-01: 10_330
+  - threshold:
+      values:
+        1995-01-01: 1
+    amount:
+      values:
+        2017-01-01: 18_340
+        2018-01-01: 18_700
+        2019-01-01: 19_030
+        2020-01-01: 19_330
+        2021-01-01: 19_520
+        2022-01-01: 20_130
+        2023-01-01: 21_560
+        2024-01-01: 22_720
+      metadata:
+        a: b
+  - threshold:
+      values:
+        1995-01-01: 2
+      metadata:
+        a: b
+    amount:
+      values:
+        2017-01-01: 18_340
+        2018-01-01: 18_700
+        2019-01-01: 19_030
+        2020-01-01: 19_330
+        2021-01-01: 19_520
+        2022-01-01: 20_130
+        2023-01-01: 21_560
+        2024-01-01: 22_720
+  - threshold:
+      values:
+        1995-01-01: 3
+      metadata:
+        a: b
+    amount:
+      values:
+        2017-01-01: 18_340
+        2018-01-01: 18_700
+        2019-01-01: 19_030
+        2020-01-01: 19_330
+        2021-01-01: 19_520
+        2022-01-01: 20_130
+        2023-01-01: 21_560
+        2024-01-01: 22_720
+      metadata:
+        a: b

--- a/tests/core/parameter_validation/test_propagate_units.py
+++ b/tests/core/parameter_validation/test_propagate_units.py
@@ -11,4 +11,6 @@ def test_propagate_units():
     parameter.propagate_units()
     for i in range(4):
         assert parameter.brackets[i].threshold.metadata["unit"] == "child"
-        assert parameter.brackets[i].amount.metadata["unit"] == "currency-USD"
+        assert parameter.brackets[i].amount.metadata["unit"] == (
+            "US dollars" if i == 1 else "currency-USD"
+        )

--- a/tests/core/parameter_validation/test_propagate_units.py
+++ b/tests/core/parameter_validation/test_propagate_units.py
@@ -1,0 +1,14 @@
+import os
+
+from policyengine_core.parameters import load_parameter_file
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def test_propagate_units():
+    path = os.path.join(BASE_DIR, "parameter_for_unit_propagation.yaml")
+    parameter = load_parameter_file(path)
+    parameter.propagate_units()
+    for i in range(4):
+        assert parameter.brackets[i].threshold.metadata["unit"] == "child"
+        assert parameter.brackets[i].amount.metadata["unit"] == "currency-USD"


### PR DESCRIPTION
- [x] `make format && make documentation` has been run.

## What's changed

- We fix #161 by adding a method for propagating units declared in the metadata of a `ParameterScale` object to the metadata of its descendants -- see the test files for an example.
- We fix #153 by updating the version of `sphinx`.