### PR TITLE
Breakdown-added parameters often precede uprating indices

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Breakdown-added parameters no longer precede uprating indices.

--- a/policyengine_core/parameters/operations/homogenize_parameters.py
+++ b/policyengine_core/parameters/operations/homogenize_parameters.py
@@ -79,7 +79,10 @@ def homogenize_parameter_node(
         node = ParameterNode(
             node.name,
             data={
-                child: {"2000-01-01": default_value}
+                child: {
+                    "0000-01-01": default_value,
+                    "2040-01-01": default_value,
+                }
                 for child in possible_values
             },
         )
@@ -91,7 +94,8 @@ def homogenize_parameter_node(
             node.add_child(
                 str(value),
                 Parameter(
-                    node.name + "." + str(value), {"2000-01-01": default_value}
+                    node.name + "." + str(value),
+                    {"0000-01-01": default_value, "2040-01-01": default_value},
                 ),
             )
     for child in node.children:


### PR DESCRIPTION
Fixes #171