### PR TITLE
Add ipython to dependencies

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    added:
+    - IPython to dependencies

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ general_requirements = [
     "requests>=2.27.1,<3",
     "pandas>=1",
     "plotly>=5.6.0,<6",
+    "ipython>=7.17.0,<8",
 ]
 
 dev_requirements = [


### PR DESCRIPTION
Fixes #191.
This PR adds IPython to `setup.py`.

## What's changed

This PR updates `setup.py` to include the `ipython` package in the `general_requirements`. The `ipython` package is now capped from (including) **version 7.17.0** to versions less than **version 8**.

These version constraints were chosen because versions equal to and greater than 7.17.0 require Python >=3.7, while versions less than 7.17.0 require Python >=3.6, and versions equal to and greater than 8 require Python >=3.8.

### Changes Made

- Added `ipython` to the `general_requirements` in `setup.py`.
- Capped `ipython` from (including) **version 7.17.0** to versions less than **version 8** to maintain compatibility with Python versions >=3.7.

