### PR TITLE
Dependency upgrade for pytest, from 7 to 8.

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    added:
+    - Dependency upgrade for pytest, from 7 to 8.

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ long_description = (this_directory / "README.md").read_text()
 # functional and integration breaks caused by external code updates.
 
 general_requirements = [
-    "pytest>=7,<8",
+    "pytest>=8,<9",
     "numpy<1.25",
     "black",
     "linecheck<1",


### PR DESCRIPTION
fixes #187 