### PR TITLE
Replace numpy-Python comparison with dtype

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Replaced unsafe numpy-Python comparison with use of numpy dtype to convert byte-string arrays to Unicode ones within enums

--- a/policyengine_core/enums/enum.py
+++ b/policyengine_core/enums/enum.py
@@ -49,8 +49,11 @@ class Enum(enum.Enum):
         if isinstance(array, EnumArray):
             return array
 
-        # if array.dtype.kind == "b":
-        if isinstance(array == 0, bool):
+        # First, convert byte-string arrays to Unicode-string arrays
+        # Confusingly, Numpy uses "S" to refer to byte-string arrays
+        # and "U" to refer to Unicode-string arrays, which are also
+        # referred to as the "str" type
+        if array.dtype.kind == "S":
             # Convert boolean array to string array
             array = array.astype(str)
 

--- a/tests/core/enums/test_enum.py
+++ b/tests/core/enums/test_enum.py
@@ -1,0 +1,39 @@
+import pytest
+import numpy as np
+from policyengine_core.enums.enum import Enum
+from policyengine_core.enums.enum_array import EnumArray
+
+
+def test_enum_creation():
+    """
+    Test to make sure that various types of numpy arrays
+    are correctly encoded to int-typed EnumArray instances;
+    check enum_array.py to see why int-typed
+    """
+
+    test_simple_array = ["MAXWELL", "DWORKIN", "MAXWELL"]
+
+    class Sample(Enum):
+        MAXWELL = "maxwell"
+        DWORKIN = "dworkin"
+
+    sample_string_array = np.array(test_simple_array)
+    sample_item_array = np.array(
+        [Sample.MAXWELL, Sample.DWORKIN, Sample.MAXWELL]
+    )
+    explicit_s_array = np.array(test_simple_array, "S")
+
+    encoded_array = Sample.encode(sample_string_array)
+    assert len(encoded_array) == 3
+    assert isinstance(encoded_array, EnumArray)
+    assert encoded_array.dtype.kind == "i"
+
+    encoded_array = Sample.encode(sample_item_array)
+    assert len(encoded_array) == 3
+    assert isinstance(encoded_array, EnumArray)
+    assert encoded_array.dtype.kind == "i"
+
+    encoded_array = Sample.encode(explicit_s_array)
+    assert len(encoded_array) == 3
+    assert isinstance(encoded_array, EnumArray)
+    assert encoded_array.dtype.kind == "i"


### PR DESCRIPTION

- [X] `make format && make documentation` has been run.

## What's changed

Fixes #100. Previously, in #205, we downgraded one line of `enums.py`. The reason for this line was previously unclear, but notably, it always runs: it takes the `array` variable, determines whether it equals 0 (which yields `True` or `False`), then determines whether the resulting value is a Boolean, which it always is. 

This was construed as a means of checking whether or not an array is of Boolean type in the comments, but what this piece of code actually does is converts all arrays passed into the function to Numpy's Unicode-string type. However, that is ambiguous due to how it's written, as well as Numpy's own confusing syntax. I believe this code also raises a `FutureWarning` because it takes a Numpy `ndarray` type and compares it with a Python type, in this case, a number.

In order to silence the warning and clean up the code, this PR instead determines whether the inbound array is of dtype "S," which confusingly stands for "bytewise-string." If so, it converts it to "str" type, which yields a dtype "U," or "Unicode-string," array.

## Tests

This was tested via a Jupyter notebook with a sample `policyengine-uk` setup that mirrors Nikhil's in #203. That said, it has not been tested with `policyengine-us`.
