### PR TITLE
Neutralising (or updating/removing) variables don't affect caching

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    fixed:
+    - Bug causing reforms affecting data to not affect caches.

--- a/policyengine_core/simulations/simulation.py
+++ b/policyengine_core/simulations/simulation.py
@@ -314,6 +314,8 @@ class Simulation:
 
         self.default_calculation_period = self.dataset.time_period
 
+        self.tax_benefit_system.data_modified = False
+
     @property
     def trace(self) -> bool:
         return self._trace
@@ -1375,7 +1377,7 @@ class Simulation:
         """
         Get the value of a variable from a cache file.
         """
-        if not self.macro_cache_read:
+        if not self.macro_cache_read or self.tax_benefit_system.data_modified:
             return None
         with h5py.File(cache_file_path, "r") as f:
             return f["values"][()]
@@ -1388,7 +1390,7 @@ class Simulation:
         """
         Set the value of a variable in a cache file.
         """
-        if not self.macro_cache_write:
+        if not self.macro_cache_write or self.tax_benefit_system.data_modified:
             return None
         with h5py.File(cache_file_path, "w") as f:
             f.create_dataset("values", data=value)

--- a/policyengine_core/taxbenefitsystems/tax_benefit_system.py
+++ b/policyengine_core/taxbenefitsystems/tax_benefit_system.py
@@ -122,6 +122,7 @@ class TaxBenefitSystem:
 
         if self.variables_dir is not None:
             self.add_variables_from_directory(self.variables_dir)
+        self.data_modified = False
 
         if self.parameters_dir is not None:
             self.load_parameters(self.parameters_dir)
@@ -228,6 +229,7 @@ class TaxBenefitSystem:
             policyengine_core.errors.VariableNameConflictError: if a variable with the same name have previously been added to the tax and benefit system.
 
         """
+        self.data_modified = True
         return self.load_variable(variable, update=False)
 
     def replace_variable(self, variable: str) -> Variable:
@@ -244,6 +246,7 @@ class TaxBenefitSystem:
         if self.variables.get(name) is not None:
             del self.variables[name]
         self.load_variable(variable, update=False)
+        self.data_modified = True
 
     def update_variable(self, variable: str) -> Variable:
         """
@@ -257,6 +260,7 @@ class TaxBenefitSystem:
 
         :param Variable variable: Variable to add. Must be a subclass of Variable.
         """
+        self.data_modified = True
         return self.load_variable(variable, update=True)
 
     def add_variables_from_file(self, file_path: str) -> None:
@@ -501,6 +505,7 @@ class TaxBenefitSystem:
         self.variables[variable_name] = variables.get_neutralized_variable(
             self.get_variable(variable_name)
         )
+        self.data_modified = True
 
     def annualize_variable(
         self, variable_name: str, period: typing.Optional[Period] = None


### PR DESCRIPTION
Fixes #213
.
Needs an update to PolicyEngine US to specify when to ignore data changes.