### PR TITLE
Adding support for Python 3.11

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Build changelog
         run: pip install yaml-changelog>=0.1.7 && make changelog
       - name: Preview changelog update
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install package
         run: make install
       - name: Run tests

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Build changelog
         run: pip install yaml-changelog && make changelog
       - name: Preview changelog update
@@ -56,7 +56,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install package
         run: make install
       - name: Run tests
@@ -69,8 +69,8 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@releases/v3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages  # The branch the action should deploy to.
-          FOLDER: docs/_build/html  # The folder the action should deploy.
+          BRANCH: gh-pages # The branch the action should deploy to.
+          FOLDER: docs/_build/html # The folder the action should deploy.
   Publish:
     runs-on: ubuntu-latest
     if: |
@@ -82,7 +82,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Publish a git tag
         run: ".github/publish-git-tag.sh || true"
       - name: Install package

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: major
+  changes:
+    added:
+      - Python 3.11 support

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Scientific/Engineering :: Information Analysis",
     ],
     description="Core microsimulation engine enabling country-specific policy models.",


### PR DESCRIPTION
[X] `make format && make documentation` has been run.

## What's changed

Added support for Python 3.11

## What this fixes and how it's fixed

Fixes #36 by adding utilities in GitHub workflows for Python 3.11. As the tests all pass in Python 3.11 on my machine, this is the only element needed for now.