### PR TITLE
Added support for Python 3.12; updated required NumPy version

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Build changelog
         run: pip install yaml-changelog>=0.1.7 && make changelog
       - name: Preview changelog update
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Install package
         run: make install
       - name: Run tests

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Build changelog
         run: pip install yaml-changelog && make changelog
       - name: Preview changelog update
@@ -56,7 +56,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Install package
         run: make install
       - name: Run tests
@@ -69,8 +69,8 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@releases/v3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages  # The branch the action should deploy to.
-          FOLDER: docs/_build/html  # The folder the action should deploy.
+          BRANCH: gh-pages # The branch the action should deploy to.
+          FOLDER: docs/_build/html # The folder the action should deploy.
   Publish:
     runs-on: ubuntu-latest
     if: |
@@ -82,7 +82,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Publish a git tag
         run: ".github/publish-git-tag.sh || true"
       - name: Install package

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: major
+  changes:
+    changed:
+      - Added support for Python 3.12

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ long_description = (this_directory / "README.md").read_text()
 
 general_requirements = [
     "pytest>=8,<9",
-    "numpy==1.26.4",
+    "numpy>=1.26.0",
     "black",
     "linecheck<1",
     "yaml-changelog<1",
@@ -58,8 +58,6 @@ setup(
         "License :: OSI Approved :: GNU Affero General Public License v3",
         "Operating System :: POSIX",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
@@ -78,7 +76,7 @@ setup(
             "policyengine-core=policyengine_core.scripts.policyengine_command:main",
         ],
     },
-    python_requires=">=3.7",
+    python_requires=">=3.9",
     extras_require={
         "dev": dev_requirements,
     },

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ long_description = (this_directory / "README.md").read_text()
 
 general_requirements = [
     "pytest>=8,<9",
-    "numpy>=1.26.0",
+    "numpy~=1.26.4",
     "black",
     "linecheck<1",
     "yaml-changelog<1",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ long_description = (this_directory / "README.md").read_text()
 
 general_requirements = [
     "pytest>=8,<9",
-    "numpy<1.25",
+    "numpy==1.26.4",
     "black",
     "linecheck<1",
     "yaml-changelog<1",
@@ -62,6 +62,8 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Scientific/Engineering :: Information Analysis",
     ],
     description="Core microsimulation engine enabling country-specific policy models.",


### PR DESCRIPTION
Thanks for contributing! Please remove any top-level sections that do not apply to your changes.

- [X] `make format && make documentation` has been run.

## What's changed

Added support for Python 3.12. To clear up issues with installation, changed the required NumPy version to 1.26.4.

## What this fixes and how it's fixed

Fixes #184 and fixes it by updating workflows and setup to accommodate Python 3.12, and updating the NumPy version to allow for installation under Python 3.12. Also fixes #182 in the process of switching NumPy to an updated version that is incompatible with both Python 3.7 and Python 3.8.