### PR TITLE
Variable uprating caused nan

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - fixed bug where uprating was causing nan.

--- a/policyengine_core/simulations/simulation.py
+++ b/policyengine_core/simulations/simulation.py
@@ -682,9 +682,7 @@ class Simulation:
                         )
 
                     array = (
-                        holder.get_array(
-                            latest_known_period, self.branch_name
-                        )
+                        holder.get_array(latest_known_period, self.branch_name)
                         * uprating_factor
                     )
                 elif (

--- a/policyengine_core/simulations/simulation.py
+++ b/policyengine_core/simulations/simulation.py
@@ -651,43 +651,42 @@ class Simulation:
             if array is None:
                 # Check if the variable has a previously defined value
                 known_periods = holder.get_known_periods()
-                if variable.uprating is not None and len(known_periods) > 0:
-                    start_instants = [
-                        str(known_period.start)
-                        for known_period in known_periods
-                        if known_period.unit == variable.definition_period
-                        and known_period.start < period.start
+                start_instants = [
+                    str(known_period.start)
+                    for known_period in known_periods
+                    if known_period.unit == variable.definition_period
+                    and known_period.start < period.start
+                ]
+                if variable.uprating is not None and len(start_instants) > 0:
+                    latest_known_period = known_periods[
+                        np.argmax(start_instants)
                     ]
-                    if len(start_instants) > 0:
-                        latest_known_period = known_periods[
-                            np.argmax(start_instants)
-                        ]
-                        try:
-                            uprating_parameter = get_parameter(
-                                self.tax_benefit_system.parameters,
-                                variable.uprating,
-                            )
-                        except:
-                            raise ValueError(
-                                f"Could not find uprating parameter {variable.uprating} when trying to uprate {variable_name}."
-                            )
-                        value_in_last_period = uprating_parameter(
-                            latest_known_period.start
+                    try:
+                        uprating_parameter = get_parameter(
+                            self.tax_benefit_system.parameters,
+                            variable.uprating,
                         )
-                        value_in_this_period = uprating_parameter(period.start)
-                        if value_in_last_period == 0:
-                            uprating_factor = 1
-                        else:
-                            uprating_factor = (
-                                value_in_this_period / value_in_last_period
-                            )
+                    except:
+                        raise ValueError(
+                            f"Could not find uprating parameter {variable.uprating} when trying to uprate {variable_name}."
+                        )
+                    value_in_last_period = uprating_parameter(
+                        latest_known_period.start
+                    )
+                    value_in_this_period = uprating_parameter(period.start)
+                    if value_in_last_period == 0:
+                        uprating_factor = 1
+                    else:
+                        uprating_factor = (
+                            value_in_this_period / value_in_last_period
+                        )
 
-                        array = (
-                            holder.get_array(
-                                latest_known_period, self.branch_name
-                            )
-                            * uprating_factor
+                    array = (
+                        holder.get_array(
+                            latest_known_period, self.branch_name
                         )
+                        * uprating_factor
+                    )
                 elif (
                     self.tax_benefit_system.auto_carry_over_input_variables
                     and variable.calculate_output is None


### PR DESCRIPTION
The following test fails for `social_security_disability` and `social_security_retirement` but not `social_security_dependents` and `social_security_survivors` because there uprating is commented out. The problem is that the if statement on line 661 of policyengine_core/simulations/simulation.py caused `array` to not be set.

```yaml
- name: Test social security adds
  input:
    social_security_survivors:
      2024: 0
    social_security_dependents:
      2024: 0
    social_security_retirement:
      2024: 0
    social_security_disability:
      2024: 0
  output:
    social_security_dependents:
      2023: 0
    social_security_survivors:
      2023: 0
    social_security_disability:
      2023: 0
    social_security_retirement:
      2023: 0
```

@MaxGhenis I don't know how to test this in the core package, but I tested in `policyengine-us` and it fixed the problem.

Related to https://github.com/PolicyEngine/policyengine-us/issues/4835