### PR TITLE
Correctly initialize reform within Simulation class

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Fixed script to initialize a reform within the simulation

--- a/policyengine_core/simulations/simulation.py
+++ b/policyengine_core/simulations/simulation.py
@@ -95,8 +95,7 @@ class Simulation:
             ):
                 tax_benefit_system = self.default_tax_benefit_system_instance
             else:
-                # If reform is taken as an arg, pass it
-                tax_benefit_system = self.default_tax_benefit_system()
+                tax_benefit_system = self.default_tax_benefit_system(reform=reform)
             self.tax_benefit_system = tax_benefit_system
 
         self.reform = reform

--- a/policyengine_core/simulations/simulation.py
+++ b/policyengine_core/simulations/simulation.py
@@ -95,7 +95,9 @@ class Simulation:
             ):
                 tax_benefit_system = self.default_tax_benefit_system_instance
             else:
-                tax_benefit_system = self.default_tax_benefit_system(reform=reform)
+                tax_benefit_system = self.default_tax_benefit_system(
+                    reform=reform
+                )
             self.tax_benefit_system = tax_benefit_system
 
         self.reform = reform


### PR DESCRIPTION
Fixes #251. 

Changes within #230 appear to have removed the portion of the `Simulation`'s initialization script that applies the reform. These changes add this back without relying upon our pre-3.2.0 usage of `reform_applied_after`.