### PR TITLE
Syntax error in Simulation class

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Syntax error in Simulation class

--- a/policyengine_core/simulations/simulation.py
+++ b/policyengine_core/simulations/simulation.py
@@ -1418,11 +1418,9 @@ class Simulation:
         """
         Check if the variable is able to have cached value
         """
-        if (
-            hasattr(self, "dataset")
-            and self.dataset.data_format == Dataset.FLAT_FILE
-        ):
-            return False
+        if hasattr(self, "dataset"):
+            if self.dataset.data_format == Dataset.FLAT_FILE:
+                return False
 
         if self.is_over_dataset:
             return True


### PR DESCRIPTION
Fixes #260 

The changes introduced within https://github.com/PolicyEngine/policyengine-core/pull/224 to create `SimulationMacroClass` unfortunately introduced a bug whereby simulations crash for every variable that does not have a dataset due to an error in evaluating conditionals joined with `and`. This fixes that error by nesting the two required statements, as similarly implemented prior to the existence of `SimulationMacroCache`.