### PR TITLE
Ensure every instance of `Simulation` class has `dataset`, fix `check_macro_cache`

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,5 @@
+- bump: patch
+  changes:
+    changed:
+    - Ensure that every instance of 'Simulation' class has 'dataset' attribute, even if equal to 'None'
+    - Add better safeguards to 'check_macro_cache' method of 'Simulation' class

--- a/policyengine_core/simulations/simulation.py
+++ b/policyengine_core/simulations/simulation.py
@@ -102,6 +102,7 @@ class Simulation:
         self.reform = reform
         self.tax_benefit_system = tax_benefit_system
         self.branch_name = "default"
+        self.dataset = dataset
 
         if dataset is None:
             if self.default_dataset is not None:
@@ -607,7 +608,7 @@ class Simulation:
 
         smc = SimulationMacroCache(self.tax_benefit_system)
 
-        # Check if cache could be used, if available, check if path exists
+        # Check if cache can be used, if available, check if path exists
         is_cache_available = self.check_macro_cache(variable_name, str(period))
         if is_cache_available:
             smc.set_cache_path(
@@ -1418,9 +1419,18 @@ class Simulation:
         """
         Check if the variable is able to have cached value
         """
-        if hasattr(self, "dataset"):
-            if self.dataset.data_format == Dataset.FLAT_FILE:
-                return False
+
+        # Dataset should always exist, but just in case
+        if not hasattr(self, "dataset"):
+            return False
+
+        # If no dataset, no need to cache
+        if self.dataset is None:
+            return False
+
+        # If using a flat file dataset, we're unable to cache
+        if self.dataset.data_format == Dataset.FLAT_FILE:
+            return False
 
         if self.is_over_dataset:
             return True


### PR DESCRIPTION
Fixes #262.

Previously, the `Simulation` class took an optional argument defaulted to `None` for a `dataset` parameter, which was used only when extending `Simulation` into classes like `MicroSimulation` and was always created with a default value of `None` if not provided. If a `dataset` was provided, it appears to have correctly integrated that into the `Simulation` instance. However, a dataset is not always provided, particularly by `pe-core`'s test runner, which does not provide one. 

This creates a confusing behavior whereby the `dataset` argument is always present, but an individual `Simulation` instance's `self.dataset` property is only created when `dataset` is not `None`. Furthermore, there are times when it appears `self.dataset` is created, but made equal to `None`. Furthermore, it's fairly easy to confuse the `self.dataset` instance attribute with the `self.datasets` class attribute, which is always present.

In order to disambiguate, this PR always instantiates a `self.dataset` instance attribute based upon the `dataset` arg, which continues to have a default value of `None`. Relying upon the expectation that `self.dataset` is always defined, it modifies the `self.check_macro_cache` method, but also adds a safety valve check to properly return `False` if `self.dataset` does not exist, just in case this PR missed some behavior somewhere.