### PR TITLE
Fix check_macro_cache logic around self.is_over_dataset

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Corrected logic with Simulation.check_macro_cache to prevent undesirable caching

--- a/policyengine_core/simulations/simulation.py
+++ b/policyengine_core/simulations/simulation.py
@@ -1432,8 +1432,8 @@ class Simulation:
         if self.dataset.data_format == Dataset.FLAT_FILE:
             return False
 
-        if self.is_over_dataset:
-            return True
+        if not self.is_over_dataset:
+            return False
 
         variable = self.tax_benefit_system.get_variable(variable_name)
         parameter_deps = variable.exhaustive_parameter_dependencies


### PR DESCRIPTION
Fixes #268. This reverts the logic within `Simulation.check_macro_cache` to ensure that when it checks the value of `self.is_over_dataset`, it follows the same logic present prior to the integration of `SimulationMacroCache`, i.e., the logic available at https://github.com/PolicyEngine/policyengine-core/blob/62e6be0d918f32e8bad85d85181223f2f50bad7e/policyengine_core/simulations/simulation.py#L1407.

This does not add tests. While `SimulationMacroCache` did when it was merged, it was unclear how it actually fit into `Simulation` itself. Moving forward, we should clarify the aims and requirements of the macro cache, refactor `Simulation` (open as https://github.com/PolicyEngine/policyengine-core/issues/264), then add tests to `Simulation` itself to prevent a similar issue