### PR TITLE
Add default_calculation_period to test runner simulation

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,5 @@
+- bump: patch
+  changes:
+    changed:
+    - Set test runner's default period as underlying simulation's default period
+    - Prevented crashing when absolutely no date is provided anywhere for tests

--- a/policyengine_core/simulations/simulation_builder.py
+++ b/policyengine_core/simulations/simulation_builder.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     )
 
 from policyengine_core.variables import Variable
+from datetime import datetime
 
 
 class SimulationBuilder:
@@ -507,6 +508,10 @@ class SimulationBuilder:
     def set_default_period(self, period_str: str) -> None:
         if period_str:
             self.default_period = str(periods.period(period_str))
+        else:
+            # If at absolute worst, no period is specified anywhere,
+            # use current year
+            self.default_period = periods.period(datetime.now().year)
 
     def get_input(self, variable: str, period_str: str) -> Any:
         if variable not in self.input_buffer:

--- a/policyengine_core/tools/test_runner.py
+++ b/policyengine_core/tools/test_runner.py
@@ -241,6 +241,7 @@ class YamlItem(pytest.Item):
             self.simulation = builder.build_from_dict(
                 self.tax_benefit_system, input
             )
+            self.simulation.default_calculation_period = builder.default_period
         except (VariableNotFoundError, SituationParsingError):
             raise
         except Exception as e:


### PR DESCRIPTION
Fixes #283. This takes the `test_builder`'s `default_period` and applies as to the underlying `Simulation` instance's `default_calculation_period`. This is as simple as popping one in for the other, since they're both the same type.

This PR also adds a fail-safe whereby, if no simulation period is defined anywhere, not even as the default fallback period for the test run, the tests just use the current year. This could be removed if failure would be preferable.