### PR TITLE
fix: Shallow copy group_entities and person_entity when cloning TBS

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    changed:
+    - Shallow copy GroupEntities and PopulationEntity when cloning TaxBenefitSystem object

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -2,3 +2,5 @@
   changes:
     changed:
     - Shallow copy GroupEntities and PopulationEntity when cloning TaxBenefitSystem object
+    added:
+    - Two tests related to extensions that were previously removed

--- a/policyengine_core/taxbenefitsystems/tax_benefit_system.py
+++ b/policyengine_core/taxbenefitsystems/tax_benefit_system.py
@@ -667,6 +667,8 @@ class TaxBenefitSystem:
                 "_parameters_at_instant_cache",
                 "variables",
                 "entities",
+                "person_entity",
+                "group_entities"
             ):
                 new_dict[key] = value
 
@@ -676,10 +678,19 @@ class TaxBenefitSystem:
             variable_name: variable.clone()
             for variable_name, variable in self.variables.items()
         }
-        new_dict["entities"] = [copy.copy(entity) for entity in self.entities]
 
+        # Apply shallow copies to all relevant entities
+        new_dict["entities"] = [copy.copy(entity) for entity in self.entities]
+        new_dict["person_entity"] = copy.copy(self.person_entity)
+        new_dict["group_entities"] = [copy.copy(entity) for entity in self.group_entities]
+
+        # For all shallow-copied entities, set entity._tax_benefit_system to the new system
         for entity in new_dict["entities"]:
             entity.set_tax_benefit_system(new)
+        for entity in new_dict["group_entities"]:
+            entity.set_tax_benefit_system(new)
+        new_dict["person_entity"].set_tax_benefit_system(new)
+        
         return new
 
     def entities_plural(self) -> dict:

--- a/policyengine_core/taxbenefitsystems/tax_benefit_system.py
+++ b/policyengine_core/taxbenefitsystems/tax_benefit_system.py
@@ -668,7 +668,7 @@ class TaxBenefitSystem:
                 "variables",
                 "entities",
                 "person_entity",
-                "group_entities"
+                "group_entities",
             ):
                 new_dict[key] = value
 
@@ -682,7 +682,9 @@ class TaxBenefitSystem:
         # Apply shallow copies to all relevant entities
         new_dict["entities"] = [copy.copy(entity) for entity in self.entities]
         new_dict["person_entity"] = copy.copy(self.person_entity)
-        new_dict["group_entities"] = [copy.copy(entity) for entity in self.group_entities]
+        new_dict["group_entities"] = [
+            copy.copy(entity) for entity in self.group_entities
+        ]
 
         # For all shallow-copied entities, set entity._tax_benefit_system to the new system
         for entity in new_dict["entities"]:
@@ -690,7 +692,7 @@ class TaxBenefitSystem:
         for entity in new_dict["group_entities"]:
             entity.set_tax_benefit_system(new)
         new_dict["person_entity"].set_tax_benefit_system(new)
-        
+
         return new
 
     def entities_plural(self) -> dict:

--- a/tests/core/test_yaml.py
+++ b/tests/core/test_yaml.py
@@ -76,6 +76,13 @@ def test_with_reform(tax_benefit_system):
     )
 
 
+def test_with_extension(tax_benefit_system):
+    assert (
+        run_yaml_test(tax_benefit_system, "test_with_extension.yaml")
+        == EXIT_OK
+    )
+
+
 def test_with_anchors(tax_benefit_system):
     assert (
         run_yaml_test(tax_benefit_system, "test_with_anchors.yaml") == EXIT_OK

--- a/tests/fixtures/yaml_tests/test_with_extension.yaml
+++ b/tests/fixtures/yaml_tests/test_with_extension.yaml
@@ -1,0 +1,28 @@
+- name: "Test using an extension"
+  period: 2017-01
+  extensions:
+    - policyengine_core.extension_template
+  input:
+    persons:
+      parent: {}
+      child1: {}
+    household:
+      parents: [parent]
+      children: [child1]
+  output:
+    local_town_child_allowance: 100
+
+- name: "Test using an extension"
+  period: 2017-01
+  extensions:
+    - policyengine_core.extension_template
+  input:
+    persons:
+      parent: {}
+      child1: {}
+      child2: {}
+    household:
+      parents: [parent]
+      children: [child1, child2]
+  output:
+    local_town_child_allowance: 200


### PR DESCRIPTION
Fixes #293.

Previous fixes to `-core` ensured that when a TaxBenefitSystem object was cloned via its internal `.clone()` method, entities themselves were shallow copied to prevent stale variable versions from being transferred between systems. However, this fix assumed that `GroupEntity` and `PopulationEntity` objects were included within the `TaxBenefitySystem`'s `entities` key, when they are not. 

This led structural reform runs to crash, as the `GroupEntity` and `PopulationEntity` would possess stale variable versions from the API's first instantiation of the default tax-benefit system, attempt to calculate using this, then crash when they couldn't find a variable that had been newly created as part of a structural reform.

This PR ensures that `GroupEntity` and `PopulationEntity` objects are also shallow-copied to prevent this behavior. This PR does not add tests at the moment, but I have opened an issue in the `-api` package laying out a comprehensive series of tests around structural reforms at https://github.com/PolicyEngine/policyengine-api/issues/1885. I have also opened a draft PR in the `-us` package to ensure these changes cause no test failures there (https://github.com/PolicyEngine/policyengine-us/pull/5240).