### PR TITLE
Datasets use atomic write when persisting to disk

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
 - bump: patch
   changes:
     fixed:
-      - DataSets writing downloaded data now use an atomic_write to write it to disk. This prevents other processes attempting to read a partial file or clobbering each other.
+      - Datasets writing downloaded data now use an atomic_write to write it to disk. This prevents other processes attempting to read a partial file or clobbering each other.

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - DataSets writing downloaded data now use an atomic_write to write it to disk. This prevents other processes attempting to read a partial file or clobbering each other.

--- a/tests/core/data/test_dataset.py
+++ b/tests/core/data/test_dataset.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from tempfile import NamedTemporaryFile
 
 
 def test_dataset_class():
@@ -24,3 +25,21 @@ def test_dataset_class():
     assert test_dataset.exists
     test_dataset.remove()
     assert not test_dataset.exists
+
+
+def test_atomic_write():
+    from policyengine_core.data.dataset import atomic_write
+
+    with NamedTemporaryFile(mode="w") as file:
+        file.write("Hello, world\n")
+        file.flush()
+        # Open the file before overwriting
+        with open(file.name, "r") as file_original:
+
+            atomic_write(Path(file.name), "NOPE\n".encode())
+
+            # Open file descriptor still points to the old node
+            assert file_original.readline() == "Hello, world\n"
+            # But if I open it again it has the new content
+            with open(file.name, "r") as file_updated:
+                assert file_updated.readline() == "NOPE\n"


### PR DESCRIPTION
Partially fixes https://github.com/PolicyEngine/policyengine-api/issues/1954

Prior to this change dataset.download() would use a normal file write to persist downloaded data to disk.

This meant another process or thread could check for the file and attempt to read it before the full content was written.

This change uses a temporary file + a rename to update the file atomically.

If a process is already reading a file that the new verion overwrites, the previous file node is unlinked rather than being overwritten so the read will work as expected.

This will allow us to back out optimistically pre-loading dataset data before it is needed (and causing 404 errors when running tests on machines without the appropriate permissions to download UK data)

Thanks for contributing! Please remove any top-level sections that do not apply to your changes.

- [x] `make format && make documentation` has been run.

# New variable

- [ ] Label field added
- [ ] Documentation field added
- [ ] Unit field added
- [ ] Default value field added if relevant
- [ ] Variable name follows conventions
- [x] Unit test(s) added
- [ ] Integration test(s) added if relevant
- [x] Issues this PR fixes linked

## What's changed

See description in the commit above

# Bug fix

- [ ] Regression test added
- [X] Regression test passing

## What this fixes and how it's fixed

See description in commit above
