### PR TITLE
Revert "Conditionally pass Hugging Face tokens for download when repo is private"

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    removed:
+    - Reverted Hugging Face token code due to unclear error

--- a/policyengine_core/data/dataset.py
+++ b/policyengine_core/data/dataset.py
@@ -497,8 +497,13 @@ class Dataset:
             file=sys.stderr,
         )
 
-        download_huggingface_dataset(
-            repo=f"{owner_name}/{model_name}",
-            repo_filename=file_name,
-            version=version,
+        token = get_or_prompt_hf_token()
+
+        hf_hub_download(
+            repo_id=f"{owner_name}/{model_name}",
+            repo_type="model",
+            filename=file_name,
+            local_dir=self.file_path.parent,
+            revision=version,
+            token=token,
         )

--- a/policyengine_core/simulations/simulation.py
+++ b/policyengine_core/simulations/simulation.py
@@ -1,6 +1,7 @@
 import tempfile
 from typing import TYPE_CHECKING, Any, Dict, List, Type, Union
 
+import numpy
 import numpy as np
 import pandas as pd
 from numpy.typing import ArrayLike
@@ -158,11 +159,7 @@ class Simulation:
                         filename = filename.split("@")[0]
                     else:
                         version = None
-                    dataset = download_huggingface_dataset(
-                        repo=f"{owner}/{repo}",
-                        repo_filename=filename,
-                        version=version,
-                    )
+                    dataset = download(owner + "/" + repo, filename, version)
                 datasets_by_name = {
                     dataset.name: dataset for dataset in self.datasets
                 }
@@ -1044,7 +1041,7 @@ class Simulation:
         if variable.value_type == Enum and not isinstance(value, EnumArray):
             return variable.possible_values.encode(value)
 
-        if not isinstance(value, np.ndarray):
+        if not isinstance(value, numpy.ndarray):
             population = self.get_variable_population(variable.name)
             value = population.filled_array(value)
 

--- a/policyengine_core/tools/hugging_face.py
+++ b/policyengine_core/tools/hugging_face.py
@@ -1,9 +1,4 @@
-from huggingface_hub import (
-    hf_hub_download,
-    model_info,
-    ModelInfo,
-)
-from huggingface_hub.errors import RepositoryNotFoundError
+from huggingface_hub import hf_hub_download, login, HfApi
 from getpass import getpass
 import os
 import warnings
@@ -12,46 +7,17 @@ with warnings.catch_warnings():
     warnings.simplefilter("ignore")
 
 
-def download_huggingface_dataset(
-    repo: str, repo_filename: str, version: str = None
-):
-    """
-    Download a dataset from the Hugging Face Hub.
-
-    Args:
-        repo (str): The Hugging Face repo name, in format "{org}/{repo}".
-        repo_filename (str): The filename of the dataset.
-        version (str, optional): The version of the dataset. Defaults to None.
-    """
-    # Attempt connection to Hugging Face model_info endpoint
-    # (https://huggingface.co/docs/huggingface_hub/v0.26.5/en/package_reference/hf_api#huggingface_hub.HfApi.model_info)
-    # Attempt to fetch model info to determine if repo is private
-    # A RepositoryNotFoundError & 401 likely means the repo is private,
-    # but this error will also surface for public repos with malformed URL, etc.
-    try:
-        fetched_model_info: ModelInfo = model_info(repo)
-        is_repo_private: bool = fetched_model_info.private
-    except RepositoryNotFoundError as e:
-        # If this error type arises, it's likely the repo is private; see docs above
-        is_repo_private = True
-        pass
-    except Exception as e:
-        # Otherwise, there probably is just a download error
-        raise Exception(
-            f"Unable to download dataset {repo_filename} from Hugging Face. This may be because the repo "
-            + "is private, the URL is malformed, or the dataset does not exist."
-        )
-
-    authentication_token: str = None
-    if is_repo_private:
-        authentication_token: str = get_or_prompt_hf_token()
+def download(repo: str, repo_filename: str, version: str = None):
+    token = os.environ.get(
+        "HUGGING_FACE_TOKEN",
+    )
 
     return hf_hub_download(
         repo_id=repo,
         repo_type="model",
         filename=repo_filename,
         revision=version,
-        token=authentication_token,
+        token=token,
     )
 
 

--- a/tests/core/tools/test_hugging_face.py
+++ b/tests/core/tools/test_hugging_face.py
@@ -1,153 +1,61 @@
 import os
 import pytest
 from unittest.mock import patch
-from huggingface_hub import ModelInfo
-from huggingface_hub.errors import RepositoryNotFoundError
-from policyengine_core.tools.hugging_face import (
-    get_or_prompt_hf_token,
-    download_huggingface_dataset,
-)
+from policyengine_core.tools.hugging_face import get_or_prompt_hf_token
 
 
-class TestHuggingFaceDownload:
-    def test_download_public_repo(self):
-        """Test downloading from a public repo"""
-        test_repo = "test_repo"
-        test_filename = "test_filename"
-        test_version = "test_version"
+def test_get_token_from_environment():
+    """Test retrieving token when it exists in environment variables"""
+    test_token = "test_token_123"
+    with patch.dict(
+        os.environ, {"HUGGING_FACE_TOKEN": test_token}, clear=True
+    ):
+        result = get_or_prompt_hf_token()
+        assert result == test_token
 
+
+def test_get_token_from_user_input():
+    """Test retrieving token via user input when not in environment"""
+    test_token = "user_input_token_456"
+
+    # Mock both empty environment and user input
+    with patch.dict(os.environ, {}, clear=True):
         with patch(
-            "policyengine_core.tools.hugging_face.hf_hub_download"
-        ) as mock_download:
-            with patch(
-                "policyengine_core.tools.hugging_face.model_info"
-            ) as mock_model_info:
-                # Create mock ModelInfo object emulating public repo
-                test_id = 0
-                mock_model_info.return_value = ModelInfo(
-                    id=test_id, private=False
-                )
-
-                download_huggingface_dataset(
-                    test_repo, test_filename, test_version
-                )
-
-                mock_download.assert_called_with(
-                    repo_id=test_repo,
-                    repo_type="model",
-                    filename=test_filename,
-                    revision=test_version,
-                    token=None,
-                )
-
-    def test_download_private_repo(self):
-        """Test downloading from a private repo"""
-        test_repo = "test_repo"
-        test_filename = "test_filename"
-        test_version = "test_version"
-
-        with patch(
-            "policyengine_core.tools.hugging_face.hf_hub_download"
-        ) as mock_download:
-            with patch(
-                "policyengine_core.tools.hugging_face.model_info"
-            ) as mock_model_info:
-                mock_model_info.side_effect = RepositoryNotFoundError(
-                    "Test error"
-                )
-                with patch(
-                    "policyengine_core.tools.hugging_face.get_or_prompt_hf_token"
-                ) as mock_token:
-                    mock_token.return_value = "test_token"
-
-                    download_huggingface_dataset(
-                        test_repo, test_filename, test_version
-                    )
-                    mock_download.assert_called_with(
-                        repo_id=test_repo,
-                        repo_type="model",
-                        filename=test_filename,
-                        revision=test_version,
-                        token=mock_token.return_value,
-                    )
-
-    def test_download_private_repo_no_token(self):
-        """Test handling of private repo with no token"""
-        test_repo = "test_repo"
-        test_filename = "test_filename"
-        test_version = "test_version"
-
-        with patch(
-            "policyengine_core.tools.hugging_face.hf_hub_download"
-        ) as mock_download:
-            with patch(
-                "policyengine_core.tools.hugging_face.model_info"
-            ) as mock_model_info:
-                mock_model_info.side_effect = RepositoryNotFoundError(
-                    "Test error"
-                )
-                with patch(
-                    "policyengine_core.tools.hugging_face.get_or_prompt_hf_token"
-                ) as mock_token:
-                    mock_token.return_value = ""
-
-                    with pytest.raises(Exception):
-                        download_huggingface_dataset(
-                            test_repo, test_filename, test_version
-                        )
-                        mock_download.assert_not_called()
-
-
-class TestGetOrPromptHfToken:
-    def test_get_token_from_environment(self):
-        """Test retrieving token when it exists in environment variables"""
-        test_token = "test_token_123"
-        with patch.dict(
-            os.environ, {"HUGGING_FACE_TOKEN": test_token}, clear=True
+            "policyengine_core.tools.hugging_face.getpass",
+            return_value=test_token,
         ):
             result = get_or_prompt_hf_token()
             assert result == test_token
 
-    def test_get_token_from_user_input(self):
-        """Test retrieving token via user input when not in environment"""
-        test_token = "user_input_token_456"
-
-        # Mock both empty environment and user input
-        with patch.dict(os.environ, {}, clear=True):
-            with patch(
-                "policyengine_core.tools.hugging_face.getpass",
-                return_value=test_token,
-            ):
-                result = get_or_prompt_hf_token()
-                assert result == test_token
-
-                # Verify token was stored in environment
-                assert os.environ.get("HUGGING_FACE_TOKEN") == test_token
-
-    def test_empty_user_input(self):
-        """Test handling of empty user input"""
-        with patch.dict(os.environ, {}, clear=True):
-            with patch(
-                "policyengine_core.tools.hugging_face.getpass", return_value=""
-            ):
-                result = get_or_prompt_hf_token()
-                assert result == ""
-                assert os.environ.get("HUGGING_FACE_TOKEN") == ""
-
-    def test_environment_variable_persistence(self):
-        """Test that environment variable persists across multiple calls"""
-        test_token = "persistence_test_token"
-
-        # First call with no environment variable
-        with patch.dict(os.environ, {}, clear=True):
-            with patch(
-                "policyengine_core.tools.hugging_face.getpass",
-                return_value=test_token,
-            ):
-                first_result = get_or_prompt_hf_token()
-
-            # Second call should use environment variable
-            second_result = get_or_prompt_hf_token()
-
-            assert first_result == second_result == test_token
+            # Verify token was stored in environment
             assert os.environ.get("HUGGING_FACE_TOKEN") == test_token
+
+
+def test_empty_user_input():
+    """Test handling of empty user input"""
+    with patch.dict(os.environ, {}, clear=True):
+        with patch(
+            "policyengine_core.tools.hugging_face.getpass", return_value=""
+        ):
+            result = get_or_prompt_hf_token()
+            assert result == ""
+            assert os.environ.get("HUGGING_FACE_TOKEN") == ""
+
+
+def test_environment_variable_persistence():
+    """Test that environment variable persists across multiple calls"""
+    test_token = "persistence_test_token"
+
+    # First call with no environment variable
+    with patch.dict(os.environ, {}, clear=True):
+        with patch(
+            "policyengine_core.tools.hugging_face.getpass",
+            return_value=test_token,
+        ):
+            first_result = get_or_prompt_hf_token()
+
+        # Second call should use environment variable
+        second_result = get_or_prompt_hf_token()
+
+        assert first_result == second_result == test_token
+        assert os.environ.get("HUGGING_FACE_TOKEN") == test_token


### PR DESCRIPTION
Reverts PolicyEngine/policyengine-core#321

Currently, in `-api`, the test at https://github.com/PolicyEngine/policyengine-api/actions/runs/12402725316/job/34625177069 fails because the API is unable to find the underlying dataset. Considering the timing and the fact that, when running locally using a previous version of `-core`, this test doesn't fail, I would imagine the cause of this problem is this code. Considering how important this code is, out of an abundance of caution, I am rolling back this code until we can determine the cause of the problem. 

If experiencing the original issue (whereby, in a `-us` notebook, one doesn't have a token for Hugging Face, and is thus unable to run any code), a very simple workaround is to just hit enter when the token is requested. The code will work as expected, as the Hugging Face US repo is public.