### PR TITLE
Encode parameter yaml as utf-8 to fix error when running on windows 

### DIFF
--- a/policyengine_core/parameters/helpers.py
+++ b/policyengine_core/parameters/helpers.py
@@ -41,7 +41,7 @@ def _compose_name(path, child_name=None, item_name=None):
 
 
 def _load_yaml_file(file_path):
-    with open(file_path, "r") as f:
+    with open(file_path, "r", encoding='utf-8') as f:
         try:
             return config.yaml.load(f, Loader=config.Loader)
         except (


### PR DESCRIPTION
Fixes #330 
