### PR TITLE
Fix/windows overflow

### DIFF
--- a/policyengine_core/commons/formulas.py
+++ b/policyengine_core/commons/formulas.py
@@ -19,6 +19,7 @@ from policyengine_core.types import ArrayLike, ArrayType
 from policyengine_core.variables.variable import Variable
 
 import json
+import pdb
 
 T = TypeVar("T")
 
@@ -329,9 +330,7 @@ def random(population):
     entity_ids = population(f"{population.entity.key}_id", period)
 
     # Generate random values for each entity
-    values = np.array(
-        [np.random.default_rng(seed=id).random() for id in entity_ids]
-    )
+    values = np.random.default_rng(seed=min(entity_ids)).random(size=len(entity_ids))
 
     return values
 

--- a/policyengine_core/commons/formulas.py
+++ b/policyengine_core/commons/formulas.py
@@ -330,12 +330,7 @@ def random(population):
 
     # Generate random values for each entity
     values = np.array(
-        [
-            np.random.default_rng(
-                seed=id * 100 + population.simulation.count_random_calls
-            ).random()
-            for id in entity_ids
-        ]
+        [np.random.default_rng(seed=id).random() for id in entity_ids]
     )
 
     return values


### PR DESCRIPTION

## What this fixes and how it's fixed

Fixes Issue #363. Moving from instantiating a different generator per entity to a single random number sequence seeded by the minimum entity id saves about 10 seconds. As long as entity id is not negative, our seed will not be negative. 


