### PR TITLE
Fix NotImplementedError usage in Projector

### DIFF
--- a/policyengine_core/projectors/projector.py
+++ b/policyengine_core/projectors/projector.py
@@ -41,4 +41,4 @@ class Projector:
             return self.parent.transform_and_bubble_up(transformed_result)
 
     def transform(self, result: ArrayLike):
-        return NotImplementedError()
+        raise NotImplementedError()


### PR DESCRIPTION
## Summary
- fix NotImplementedError usage in `Projector.transform`

## Testing
- `pytest tests/test_us.py::test_policyengine_us_microsimulation_runs -q` *(fails: ProxyError)*