### PR TITLE
Fix NotImplementedError usage in Projector

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,6 @@
+- bump: patch
+  changes:
+    fixed:
+    - Projector.transform now raises NotImplementedError
+    added:
+    - regression test ensuring base Projector.transform raises

--- a/policyengine_core/projectors/projector.py
+++ b/policyengine_core/projectors/projector.py
@@ -41,4 +41,4 @@ class Projector:
             return self.parent.transform_and_bubble_up(transformed_result)
 
     def transform(self, result: ArrayLike):
-        return NotImplementedError()
+        raise NotImplementedError()

--- a/tests/core/test_projectors.py
+++ b/tests/core/test_projectors.py
@@ -1,9 +1,19 @@
 import numpy as np
+import pytest
 
 from policyengine_core.entities import build_entity
 from policyengine_core.model_api import ETERNITY, Enum, Variable
 from policyengine_core.simulations.simulation_builder import SimulationBuilder
+
 from policyengine_core.taxbenefitsystems import TaxBenefitSystem
+
+
+def test_base_projector_transform_raises():
+    from policyengine_core.projectors.projector import Projector
+
+    projector = Projector()
+    with pytest.raises(NotImplementedError):
+        projector.transform([])
 
 
 def test_shortcut_to_containing_entity_provided():


### PR DESCRIPTION
## Summary
- fix NotImplementedError usage in `Projector.transform`
- add regression test for Projector base class

## Testing
- `pytest tests/core/test_projectors.py::test_base_projector_transform_raises -q`
