### PR TITLE
Fix vectorial parameter default lookup

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Vectorized parameter lookup no longer raises ValueError when the first key is missing.

--- a/policyengine_core/parameters/vectorial_parameter_node_at_instant.py
+++ b/policyengine_core/parameters/vectorial_parameter_node_at_instant.py
@@ -216,8 +216,10 @@ class VectorialParameterNodeAtInstant:
             names = list(
                 self.dtype.names
             )  # Get all the names of the subnodes, e.g. ['zone_1', 'zone_2']
+            # Build a default array using an existing field rather than the key,
+            # which might be missing from the dataset.
             default = numpy.full_like(
-                self.vector[key[0]], numpy.nan
+                self.vector[names[0]], numpy.nan
             )  # In case of unexpected key, we will set the corresponding value to NaN.
             conditions = [key == name for name in names]
             values = [self.vector[name] for name in names]

--- a/tests/core/parameters_fancy_indexing/test_fancy_indexing.py
+++ b/tests/core/parameters_fancy_indexing/test_fancy_indexing.py
@@ -98,6 +98,13 @@ def test_wrong_key():
     assert "'rate.single.owner.toto' was not found" in get_message(e.value)
 
 
+def test_wrong_key_first():
+    zone = np.asarray(["toto", "z2", "z2", "z1"])
+    with pytest.raises(ParameterNotFoundError) as e:
+        P.single.owner[zone]
+    assert "'rate.single.owner.toto' was not found" in get_message(e.value)
+
+
 P_2 = parameters.local_tax("2015-01-01")
 
 


### PR DESCRIPTION
## Summary
- fix default creation when keys may be missing
- test missing key as first index
- add changelog entry

## Testing
- `make format`
- `make test` *(fails: policyengine-core command not found)*
- `pytest tests/core/parameters_fancy_indexing/test_fancy_indexing.py::test_wrong_key_first -q` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684894c660808326aa098007bc8cbbd6