### PR TITLE
Fix NumPy 2.x structured array dtype compatibility for axes

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - NumPy 2.x structured array dtype compatibility when using axes with parameters that have different field subsets (e.g., ACA rating areas)

--- a/policyengine_core/parameters/vectorial_parameter_node_at_instant.py
+++ b/policyengine_core/parameters/vectorial_parameter_node_at_instant.py
@@ -223,9 +223,15 @@ class VectorialParameterNodeAtInstant:
 
             # NumPy 2.x requires all arrays in numpy.select to have identical dtypes
             # For structured arrays with different field sets, we need to normalize them
-            if len(values) > 0 and hasattr(values[0].dtype, 'names') and values[0].dtype.names:
+            if (
+                len(values) > 0
+                and hasattr(values[0].dtype, "names")
+                and values[0].dtype.names
+            ):
                 # Check if all values have the same dtype
-                dtypes_match = all(val.dtype == values[0].dtype for val in values)
+                dtypes_match = all(
+                    val.dtype == values[0].dtype for val in values
+                )
 
                 if not dtypes_match:
                     # Find the union of all field names across all values, preserving first seen order
@@ -238,7 +244,9 @@ class VectorialParameterNodeAtInstant:
                                 seen.add(field)
 
                     # Create unified dtype with all fields
-                    unified_dtype = numpy.dtype([(f, '<f8') for f in all_fields])
+                    unified_dtype = numpy.dtype(
+                        [(f, "<f8") for f in all_fields]
+                    )
 
                     # Cast all values to unified dtype
                     values_cast = []
@@ -248,7 +256,9 @@ class VectorialParameterNodeAtInstant:
                             casted[field] = val[field]
                         values_cast.append(casted)
 
-                    default = numpy.zeros(len(values_cast[0]), dtype=unified_dtype)
+                    default = numpy.zeros(
+                        len(values_cast[0]), dtype=unified_dtype
+                    )
                     # Fill with NaN
                     for field in unified_dtype.names:
                         default[field] = numpy.nan
@@ -260,7 +270,9 @@ class VectorialParameterNodeAtInstant:
                     result = numpy.select(conditions, values, default)
             else:
                 # Non-structured array case
-                default = numpy.full_like(values[0] if values else self.vector[key[0]], numpy.nan)
+                default = numpy.full_like(
+                    values[0] if values else self.vector[key[0]], numpy.nan
+                )
                 result = numpy.select(conditions, values, default)
 
             # Check for unexpected keys (NaN results from missing keys)
@@ -269,7 +281,8 @@ class VectorialParameterNodeAtInstant:
                 if unexpected_keys:
                     unexpected_key = unexpected_keys.pop()
                     raise ParameterNotFoundError(
-                        ".".join([self._name, unexpected_key]), self._instant_str
+                        ".".join([self._name, unexpected_key]),
+                        self._instant_str,
                     )
 
             # If the result is not a leaf, wrap the result in a vectorial node.

--- a/tests/core/parameters/test_numpy2_structured_arrays.py
+++ b/tests/core/parameters/test_numpy2_structured_arrays.py
@@ -44,7 +44,7 @@ def test_structured_array_with_numeric_string_fields():
 
     # Test with keys that will trigger alphabetic sorting issues
     # When you have '1', '2', '10', NumPy might sort them as '1', '10', '2'
-    keys = np.array(['1', '2', '10'])
+    keys = np.array(["1", "2", "10"])
 
     # This should work but may fail with NumPy 2.x due to dtype field ordering
     result = node[keys]
@@ -62,14 +62,14 @@ def test_structured_array_field_order_preservation():
     NumPy 2.x is stricter about dtype matching - field order must be identical.
     """
     # Create array with fields in non-alphabetical order
-    dtype = np.dtype([('z', float), ('a', float), ('m', float)])
+    dtype = np.dtype([("z", float), ("a", float), ("m", float)])
     data = np.array([(1.0, 2.0, 3.0), (4.0, 5.0, 6.0)], dtype=dtype)
     vector = data.view(np.recarray)
 
     node = VectorialParameterNodeAtInstant("test", vector, "2024-01-01")
 
     # Test with array key - must match vector length
-    keys = np.array(['z', 'm'])
+    keys = np.array(["z", "m"])
     result = node[keys]
 
     # Should return correct values

--- a/tests/core/parameters/test_numpy2_structured_arrays.py
+++ b/tests/core/parameters/test_numpy2_structured_arrays.py
@@ -1,8 +1,11 @@
 """Test NumPy 2.x compatibility with structured arrays in vectorial parameters.
 
-This test reproduces the issue where numpy.select() fails with NumPy 2.x
-when using structured arrays with numeric string field names that get
-sorted differently (e.g., '1', '10', '2' vs '1', '2', '10').
+This test reproduces and verifies the fix for the issue where numpy.select()
+fails with NumPy 2.x when using structured arrays with numeric string field
+names that get sorted differently (e.g., '1', '10', '2' vs '1', '2', '10').
+
+This commonly occurs when using axes with state-based parameters like ACA
+rating areas, where different states have different numbers of rating areas.
 """
 
 import numpy as np
@@ -76,3 +79,64 @@ def test_structured_array_field_order_preservation():
     assert len(result) == 2
     assert result[0] == pytest.approx(1.0)  # Row 0, field 'z'
     assert result[1] == pytest.approx(6.0)  # Row 1, field 'm'
+
+
+def test_mismatched_structured_array_fields():
+    """Test structured arrays with different field subsets (real ACA scenario).
+
+    This tests the dtype unification code path that handles arrays with
+    different field subsets.
+    """
+    # Create states with different rating area fields (like real ACA data)
+    # Each row represents an age bracket, each field a rating area
+    dtype_ca = np.dtype([("1", float), ("2", float), ("3", float)])
+    dtype_ny = np.dtype([("10", float), ("11", float)])  # Different fields
+
+    # Create data for 2 rows (age brackets)
+    data_ca = np.array([(100.0, 110.0, 120.0), (200.0, 210.0, 220.0)], dtype=dtype_ca)
+    data_ny = np.array([(300.0, 310.0), (400.0, 410.0)], dtype=dtype_ny)
+
+    # Create parent structure with both states
+    parent_dtype = np.dtype([("CA", dtype_ca), ("NY", dtype_ny)])
+    parent_data = np.array([
+        (data_ca[0], data_ny[0]),
+        (data_ca[1], data_ny[1])
+    ], dtype=parent_dtype)
+    parent_vector = parent_data.view(np.recarray)
+
+    node = VectorialParameterNodeAtInstant("states", parent_vector, "2024-01-01")
+
+    # Access both states - this triggers dtype mismatch handling
+    keys = np.array(["CA", "NY"])
+    result = node[keys]
+
+    # Result is wrapped in VectorialParameterNodeAtInstant for structured arrays
+    assert isinstance(result, (np.ndarray, VectorialParameterNodeAtInstant))
+    if isinstance(result, VectorialParameterNodeAtInstant):
+        assert len(result.vector) == 2
+    else:
+        assert len(result) == 2
+
+
+def test_all_dtypes_match_optimization():
+    """Test that when all dtypes match, we use the optimized path."""
+    # Create uniform arrays where all states have the same fields
+    dtype = np.dtype([("1", float), ("2", float)])
+    data = np.array([
+        ((100.0, 110.0), (200.0, 210.0)),
+        ((300.0, 310.0), (400.0, 410.0))
+    ], dtype=[("state1", dtype), ("state2", dtype)])
+    vector = data.view(np.recarray)
+
+    node = VectorialParameterNodeAtInstant("test", vector, "2024-01-01")
+
+    # When all dtypes match, should use optimized code path
+    keys = np.array(["state1", "state2"])
+    result = node[keys]
+
+    # Result is wrapped for structured arrays
+    assert isinstance(result, (np.ndarray, VectorialParameterNodeAtInstant))
+    if isinstance(result, VectorialParameterNodeAtInstant):
+        assert len(result.vector) == 2
+    else:
+        assert len(result) == 2

--- a/tests/core/parameters/test_numpy2_structured_arrays.py
+++ b/tests/core/parameters/test_numpy2_structured_arrays.py
@@ -93,18 +93,22 @@ def test_mismatched_structured_array_fields():
     dtype_ny = np.dtype([("10", float), ("11", float)])  # Different fields
 
     # Create data for 2 rows (age brackets)
-    data_ca = np.array([(100.0, 110.0, 120.0), (200.0, 210.0, 220.0)], dtype=dtype_ca)
+    data_ca = np.array(
+        [(100.0, 110.0, 120.0), (200.0, 210.0, 220.0)], dtype=dtype_ca
+    )
     data_ny = np.array([(300.0, 310.0), (400.0, 410.0)], dtype=dtype_ny)
 
     # Create parent structure with both states
     parent_dtype = np.dtype([("CA", dtype_ca), ("NY", dtype_ny)])
-    parent_data = np.array([
-        (data_ca[0], data_ny[0]),
-        (data_ca[1], data_ny[1])
-    ], dtype=parent_dtype)
+    parent_data = np.array(
+        [(data_ca[0], data_ny[0]), (data_ca[1], data_ny[1])],
+        dtype=parent_dtype,
+    )
     parent_vector = parent_data.view(np.recarray)
 
-    node = VectorialParameterNodeAtInstant("states", parent_vector, "2024-01-01")
+    node = VectorialParameterNodeAtInstant(
+        "states", parent_vector, "2024-01-01"
+    )
 
     # Access both states - this triggers dtype mismatch handling
     keys = np.array(["CA", "NY"])
@@ -122,10 +126,10 @@ def test_all_dtypes_match_optimization():
     """Test that when all dtypes match, we use the optimized path."""
     # Create uniform arrays where all states have the same fields
     dtype = np.dtype([("1", float), ("2", float)])
-    data = np.array([
-        ((100.0, 110.0), (200.0, 210.0)),
-        ((300.0, 310.0), (400.0, 410.0))
-    ], dtype=[("state1", dtype), ("state2", dtype)])
+    data = np.array(
+        [((100.0, 110.0), (200.0, 210.0)), ((300.0, 310.0), (400.0, 410.0))],
+        dtype=[("state1", dtype), ("state2", dtype)],
+    )
     vector = data.view(np.recarray)
 
     node = VectorialParameterNodeAtInstant("test", vector, "2024-01-01")

--- a/tests/core/parameters/test_numpy2_structured_arrays.py
+++ b/tests/core/parameters/test_numpy2_structured_arrays.py
@@ -19,43 +19,41 @@ def test_structured_array_with_numeric_string_fields():
     This reproduces the issue where field names like '1', '2', ..., '10', '11'
     get sorted alphabetically by NumPy ('1', '10', '11', '2', ...) causing
     dtype mismatches in numpy.select().
+
+    The real ACA rating_area parameters have 67 rating areas for some states,
+    which triggers alphabetic vs numeric sorting issues.
     """
-    # Create a structured array with numeric string field names like ACA rating areas
-    # This mimics the structure of ACA state_rating_area_cost parameters
-    dtype = np.dtype([
-        ('1', float), ('2', float), ('3', float), ('4', float), ('5', float),
-        ('10', float), ('11', float), ('12', float)
-    ])
+    # Create a structured array with ALL numeric string field names 1-67
+    # This mimics the actual ACA state_rating_area_cost structure
+    field_names = [str(i) for i in range(1, 68)]  # '1' through '67'
+    dtype = np.dtype([(name, float) for name in field_names])
 
-    # Create test data - this simulates parameter data with multiple rating areas
-    data = np.array([
-        (100.0, 110.0, 120.0, 130.0, 140.0, 150.0, 160.0, 170.0),
-        (200.0, 210.0, 220.0, 230.0, 240.0, 250.0, 260.0, 270.0),
-    ], dtype=dtype)
+    # Create test data with 3 rows (simulates 3 age brackets or similar)
+    test_values = []
+    for row in range(3):
+        row_data = tuple(float(i * 10 + row) for i in range(1, 68))
+        test_values.append(row_data)
+    data = np.array(test_values, dtype=dtype)
 
-    # Create a vectorial parameter node (this simulates how PolicyEngine stores parameters)
+    # Create a vectorial parameter node
     vector = data.view(np.recarray)
     instant_str = "2024-01-01"
     name = "test_rating_areas"
 
     node = VectorialParameterNodeAtInstant(name, vector, instant_str)
 
-    # Test indexing with a key array (simulates axes creating multiple values)
-    # This is what fails in the real scenario - when axes creates multiple
-    # households with different rating areas
+    # Test with keys that will trigger alphabetic sorting issues
+    # When you have '1', '2', '10', NumPy might sort them as '1', '10', '2'
     keys = np.array(['1', '2', '10'])
 
-    # This should work but fails with NumPy 2.x due to dtype field ordering
+    # This should work but may fail with NumPy 2.x due to dtype field ordering
     result = node[keys]
 
     # Verify results
     assert len(result) == 3
-    # First household gets rating area '1' values
-    assert result[0] == pytest.approx(100.0) or result[0] == pytest.approx(200.0)
-    # Second household gets rating area '2' values
-    assert result[1] == pytest.approx(110.0) or result[1] == pytest.approx(210.0)
-    # Third household gets rating area '10' values
-    assert result[2] == pytest.approx(150.0) or result[2] == pytest.approx(250.0)
+    assert result[0] == pytest.approx(10.0)  # Row 0, field '1'
+    assert result[1] == pytest.approx(21.0)  # Row 1, field '2'
+    assert result[2] == pytest.approx(102.0)  # Row 2, field '10'
 
 
 def test_structured_array_field_order_preservation():
@@ -70,12 +68,11 @@ def test_structured_array_field_order_preservation():
 
     node = VectorialParameterNodeAtInstant("test", vector, "2024-01-01")
 
-    # Test with array key
-    keys = np.array(['z', 'm', 'a'])
+    # Test with array key - must match vector length
+    keys = np.array(['z', 'm'])
     result = node[keys]
 
     # Should return correct values
-    assert len(result) == 3
-    assert result[0] in [1.0, 4.0]  # 'z' field
-    assert result[1] in [3.0, 6.0]  # 'm' field
-    assert result[2] in [2.0, 5.0]  # 'a' field
+    assert len(result) == 2
+    assert result[0] == pytest.approx(1.0)  # Row 0, field 'z'
+    assert result[1] == pytest.approx(6.0)  # Row 1, field 'm'

--- a/tests/core/parameters/test_numpy2_structured_arrays.py
+++ b/tests/core/parameters/test_numpy2_structured_arrays.py
@@ -1,0 +1,81 @@
+"""Test NumPy 2.x compatibility with structured arrays in vectorial parameters.
+
+This test reproduces the issue where numpy.select() fails with NumPy 2.x
+when using structured arrays with numeric string field names that get
+sorted differently (e.g., '1', '10', '2' vs '1', '2', '10').
+"""
+
+import numpy as np
+import pytest
+from policyengine_core.parameters import ParameterNode
+from policyengine_core.parameters.vectorial_parameter_node_at_instant import (
+    VectorialParameterNodeAtInstant,
+)
+
+
+def test_structured_array_with_numeric_string_fields():
+    """Test that vectorial parameters work with NumPy 2.x structured arrays.
+
+    This reproduces the issue where field names like '1', '2', ..., '10', '11'
+    get sorted alphabetically by NumPy ('1', '10', '11', '2', ...) causing
+    dtype mismatches in numpy.select().
+    """
+    # Create a structured array with numeric string field names like ACA rating areas
+    # This mimics the structure of ACA state_rating_area_cost parameters
+    dtype = np.dtype([
+        ('1', float), ('2', float), ('3', float), ('4', float), ('5', float),
+        ('10', float), ('11', float), ('12', float)
+    ])
+
+    # Create test data - this simulates parameter data with multiple rating areas
+    data = np.array([
+        (100.0, 110.0, 120.0, 130.0, 140.0, 150.0, 160.0, 170.0),
+        (200.0, 210.0, 220.0, 230.0, 240.0, 250.0, 260.0, 270.0),
+    ], dtype=dtype)
+
+    # Create a vectorial parameter node (this simulates how PolicyEngine stores parameters)
+    vector = data.view(np.recarray)
+    instant_str = "2024-01-01"
+    name = "test_rating_areas"
+
+    node = VectorialParameterNodeAtInstant(name, vector, instant_str)
+
+    # Test indexing with a key array (simulates axes creating multiple values)
+    # This is what fails in the real scenario - when axes creates multiple
+    # households with different rating areas
+    keys = np.array(['1', '2', '10'])
+
+    # This should work but fails with NumPy 2.x due to dtype field ordering
+    result = node[keys]
+
+    # Verify results
+    assert len(result) == 3
+    # First household gets rating area '1' values
+    assert result[0] == pytest.approx(100.0) or result[0] == pytest.approx(200.0)
+    # Second household gets rating area '2' values
+    assert result[1] == pytest.approx(110.0) or result[1] == pytest.approx(210.0)
+    # Third household gets rating area '10' values
+    assert result[2] == pytest.approx(150.0) or result[2] == pytest.approx(250.0)
+
+
+def test_structured_array_field_order_preservation():
+    """Test that field order is preserved when creating default arrays.
+
+    NumPy 2.x is stricter about dtype matching - field order must be identical.
+    """
+    # Create array with fields in non-alphabetical order
+    dtype = np.dtype([('z', float), ('a', float), ('m', float)])
+    data = np.array([(1.0, 2.0, 3.0), (4.0, 5.0, 6.0)], dtype=dtype)
+    vector = data.view(np.recarray)
+
+    node = VectorialParameterNodeAtInstant("test", vector, "2024-01-01")
+
+    # Test with array key
+    keys = np.array(['z', 'm', 'a'])
+    result = node[keys]
+
+    # Should return correct values
+    assert len(result) == 3
+    assert result[0] in [1.0, 4.0]  # 'z' field
+    assert result[1] in [3.0, 6.0]  # 'm' field
+    assert result[2] in [2.0, 5.0]  # 'a' field


### PR DESCRIPTION
## Summary
Fixes the issue where `numpy.select()` fails with NumPy 2.x when using axes with state-based parameters that have structured arrays with different field subsets (e.g., ACA rating areas).

## The Problem
When calculating health benefits with axes in PolicyEngine-US:
1. Different states have different numbers of ACA rating areas
2. This creates structured arrays with different field subsets  
3. NumPy 2.x's `numpy.select()` requires exact dtype matches including field order
4. Field names like '1', '2', '10' get sorted alphabetically differently across arrays ('1', '10', '2' vs '10', '2', '3')
5. This causes `TypeError: Choicelist and default value do not have a common dtype`

## The Solution
- Detect when structured array values have mismatched dtypes
- Find the union of all field names across all values
- Cast all values to a unified dtype with all fields
- Missing fields are filled with NaN (expected behavior)
- Only raise ParameterNotFoundError for truly missing keys

## Test Plan  
- [x] Added test cases for structured arrays with numeric string fields
- [x] All existing parameter tests pass
- [x] Verified fix works with PolicyEngine-US health benefits + axes
- [x] Tested in marginal-child app - health benefits now calculate correctly

## Impact
Enables health benefits calculations (Medicaid, CHIP, ACA PTC) to work correctly with axes in PolicyEngine-US, allowing applications to show accurate marginal benefit analysis including health insurance value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>