### PR TITLE
Add policyengine-claude plugin auto-install

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "plugins": {
+    "marketplaces": [
+      "PolicyEngine/policyengine-claude"
+    ],
+    "auto_install": [
+      "country-models@policyengine-claude"
+    ]
+  }
+}

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    changed:
+      - Added policyengine-claude plugin auto-install configuration.

--- a/policyengine_core/charts/formatting.py
+++ b/policyengine_core/charts/formatting.py
@@ -1,7 +1,6 @@
 import plotly.graph_objects as go
 from IPython.display import HTML
 
-
 GREEN = "#29d40f"
 LIGHT_GREEN = "#C5E1A5"
 DARK_GREEN = "#558B2F"

--- a/policyengine_core/populations/population.py
+++ b/policyengine_core/populations/population.py
@@ -72,17 +72,13 @@ class Population:
         if period is None:
             stack = traceback.extract_stack()
             filename, line_number, function_name, line_of_code = stack[-3]
-            raise ValueError(
-                """
+            raise ValueError("""
 You requested computation of variable "{}", but you did not specify on which period in "{}:{}":
     {}
 When you request the computation of a variable within a formula, you must always specify the period as the second parameter. The convention is to call this parameter "period". For example:
     computed_salary = person('salary', period).
 See more information at <https://openfisca.org/doc/coding-the-legislation/35_periods.html#periods-in-variable-definition>.
-""".format(
-                    variable_name, filename, line_number, line_of_code
-                )
-            )
+""".format(variable_name, filename, line_number, line_of_code))
 
     def __call__(
         self,


### PR DESCRIPTION
## Summary

Adds auto-install configuration for the policyengine-claude plugin.

## What This Does

When you trust this repo in Claude Code, the [policyengine-claude plugin](https://github.com/PolicyEngine/policyengine-claude) auto-installs, providing:

- **15+ specialized agents** for PolicyEngine development
- **Slash commands** like `/encode-policy`, `/review-pr`
- **Skills** for simulation patterns and code standards

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)