### PR TITLE
Add Python 3.14 support

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -63,6 +63,8 @@ jobs:
     name: Test Core and country packages (${{ matrix.os }}, py${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
     needs: Lint
+    # Python 3.14 smoke tests allowed to fail until tables has 3.14 wheels
+    continue-on-error: ${{ matrix.python-version == '3.14' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -63,8 +63,6 @@ jobs:
     name: Test Core and country packages (${{ matrix.os }}, py${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
     needs: Lint
-    # Python 3.14 smoke tests allowed to fail until tables has 3.14 wheels
-    continue-on-error: ${{ matrix.python-version == '3.14' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        python-version: [ "3.12", "3.13" ]
+        python-version: [ "3.12", "3.13", "3.14" ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -67,7 +67,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -83,7 +83,7 @@ jobs:
         run: python -m pytest --version
       - name: Install -us package from PyPI
         run: |
-          if [[ "${{ matrix.python-version }}" == "3.13" ]]; then
+          if [[ "${{ matrix.python-version }}" == "3.13" || "${{ matrix.python-version }}" == "3.14" ]]; then
             # For Python 3.13, install newer tables first and ignore conflicts
             pip install "tables>=3.10.1"
             pip install policyengine-us --no-deps

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -67,7 +67,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        # Python 3.14 excluded until tables 3.11 releases (PyTables/PyTables#1262)
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -83,10 +84,9 @@ jobs:
         run: python -m pytest --version
       - name: Install -us package from PyPI
         run: |
-          if [[ "${{ matrix.python-version }}" == "3.13" || "${{ matrix.python-version }}" == "3.14" ]]; then
-            # For Python 3.13+, install newer tables first and ignore conflicts
-            # Python 3.14 requires tables>=3.11 (PyTables/PyTables#1262)
-            pip install "tables>=3.11"
+          if [[ "${{ matrix.python-version }}" == "3.13" ]]; then
+            # For Python 3.13, install newer tables first and ignore conflicts
+            pip install "tables>=3.10.1"
             pip install policyengine-us --no-deps
             # Install remaining dependencies manually
             pip install click==8.1.3 pathlib pytest-dependency synthimpute tabulate

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -67,8 +67,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        # Python 3.14 excluded until tables 3.11 releases (PyTables/PyTables#1262)
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -84,9 +83,9 @@ jobs:
         run: python -m pytest --version
       - name: Install -us package from PyPI
         run: |
-          if [[ "${{ matrix.python-version }}" == "3.13" ]]; then
-            # For Python 3.13, install newer tables first and ignore conflicts
-            pip install "tables>=3.10.1"
+          if [[ "${{ matrix.python-version }}" == "3.13" || "${{ matrix.python-version }}" == "3.14" ]]; then
+            # Python 3.14 requires tables>=3.11 (PyTables/PyTables#1262)
+            pip install "tables>=3.11"
             pip install policyengine-us --no-deps
             # Install remaining dependencies manually
             pip install click==8.1.3 pathlib pytest-dependency synthimpute tabulate

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -82,18 +82,8 @@ jobs:
       - name: Verify pytest plugins
         run: python -m pytest --version
       - name: Install -us package from PyPI
-        run: |
-          if [[ "${{ matrix.python-version }}" == "3.13" || "${{ matrix.python-version }}" == "3.14" ]]; then
-            # Python 3.14 requires tables>=3.11 (PyTables/PyTables#1262)
-            pip install "tables>=3.11"
-            pip install policyengine-us --no-deps
-            # Install remaining dependencies manually
-            pip install click==8.1.3 pathlib pytest-dependency synthimpute tabulate
-            pip install policyengine-us-data --no-deps
-          else
-            python -m pip install policyengine-us
-          fi
-        shell: bash
+        # Python 3.14 blocked until tables 3.11 releases (PyTables/PyTables#1262)
+        run: python -m pip install policyengine-us
       - name: Run smoke tests only
         run: python -m pytest -m smoke --reruns 2 --reruns-delay 5 -v -s
         env:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -84,8 +84,9 @@ jobs:
       - name: Install -us package from PyPI
         run: |
           if [[ "${{ matrix.python-version }}" == "3.13" || "${{ matrix.python-version }}" == "3.14" ]]; then
-            # For Python 3.13, install newer tables first and ignore conflicts
-            pip install "tables>=3.10.1"
+            # For Python 3.13+, install newer tables first and ignore conflicts
+            # Python 3.14 requires tables>=3.11 (PyTables/PyTables#1262)
+            pip install "tables>=3.11"
             pip install policyengine-us --no-deps
             # Install remaining dependencies manually
             pip install click==8.1.3 pathlib pytest-dependency synthimpute tabulate

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+    - Python 3.14 support.

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Topic :: Scientific/Engineering :: Information Analysis",
     ],
     description="Core microsimulation engine enabling country-specific policy models.",

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ dev_requirements = [
 
 setup(
     name="policyengine-core",
-    version="3.23.4",
+    version="3.24.0",
     author="PolicyEngine",
     author_email="hello@policyengine.org",
     classifiers=[


### PR DESCRIPTION
## Summary
Add Python 3.14 support to policyengine-core.

## Status: Blocked on tables
⚠️ **Waiting on [PyTables/PyTables#1262](https://github.com/PyTables/PyTables/issues/1262)** — tables doesn't have Python 3.14 wheels yet, and source builds fail. This blocks microsimulation functionality (loading CPS/microdata).

Once tables 3.11.0 ships with Python 3.14 support, this PR can be merged.

## Changes
- Add Python 3.14 to classifiers in setup.py
- Add Python 3.14 to Test matrix in pr.yaml (3.12, 3.13, 3.14)
- Add Python 3.14 to SmokeTestForMultipleVersions matrix (3.10-3.14)
- Handle Python 3.14 like 3.13 for `tables` package workaround

## What works now
- policyengine-core installs and runs on Python 3.14 ✅
- Household-level calculations work ✅

## What's blocked
- Microsimulation (requires tables → policyengine-us-data → HDF5 microdata)

## Dependencies
The numpy compatibility fix for Python 3.14 was already merged in PR #409.

## Test plan
- CI runs tests on Python 3.10, 3.11, 3.12, 3.13, and 3.14
- Core tests pass on all versions
- Smoke tests with policyengine-us will pass once tables has 3.14 wheels

## Related issue
Fixes #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)