### PR TITLE
Remove stale smoke test workaround

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -82,18 +82,7 @@ jobs:
       - name: Verify pytest plugins
         run: python -m pytest --version
       - name: Install -us package from PyPI
-        run: |
-          if [[ "${{ matrix.python-version }}" == "3.13" ]]; then
-            # For Python 3.13, install newer tables first and ignore conflicts
-            pip install "tables>=3.10.1"
-            pip install policyengine-us --no-deps
-            # Install remaining dependencies manually
-            pip install click==8.1.3 pathlib pytest-dependency synthimpute tabulate
-            pip install policyengine-us-data --no-deps
-          else
-            python -m pip install policyengine-us
-          fi
-        shell: bash
+        run: python -m pip install policyengine-us
       - name: Run smoke tests only
         run: python -m pytest -m smoke --reruns 2 --reruns-delay 5 -v -s
         env:

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    removed:
+    - Stale smoke test workaround with unused dependencies (synthimpute, etc.).

--- a/setup.py
+++ b/setup.py
@@ -82,8 +82,6 @@ setup(
     python_requires=">=3.10",
     extras_require={
         "dev": dev_requirements,
-        # Note: For Python 3.13, policyengine-us requires special installation
-        # due to tables==3.9.2 not having Python 3.13 wheels. See CI workflow for workaround.
     },
     include_package_data=True,  # Will read MANIFEST.in
     install_requires=general_requirements,


### PR DESCRIPTION
## Summary
Clean up stale smoke test workaround that installed unused dependencies.

## Changes
- Remove Python 3.13 special handling (tables 3.10.2+ has 3.13 wheels now)
- Remove unused dependencies: `synthimpute`, `click`, `pathlib`, `pytest-dependency`, `tabulate`
- Remove stale comment in setup.py

## Why
The workaround was added when tables didn't have Python 3.13 wheels. Now that tables>=3.10.2 supports 3.13, the workaround is unnecessary. The dependencies it installed (especially synthimpute) haven't been used by PolicyEngine in a long time.

## Test plan
- CI will verify that `pip install policyengine-us` works on Python 3.10-3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)