### PR TITLE
Fix pandas 3.0 KeyError in Enum.encode() for Series with non-integer index

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Fixed pandas 3.0 compatibility in Enum.encode() by using positional access (.iloc[0]) for pandas Series instead of label-based access (array[0]), which fails with KeyError when Series has a non-integer index (fixes #427)

--- a/policyengine_core/enums/enum.py
+++ b/policyengine_core/enums/enum.py
@@ -66,7 +66,14 @@ class Enum(enum.Enum):
             return array
 
         # Handle Enum item arrays by extracting indices directly
-        if len(array) > 0 and isinstance(array[0], Enum):
+        # Use .iloc[0] for pandas Series to avoid KeyError with non-integer index
+        # (pandas 3.0 uses StringDtype by default, causing array[0] to do
+        # label-based lookup instead of positional access)
+        if len(array) > 0:
+            first_elem = array.iloc[0] if hasattr(array, "iloc") else array[0]
+        else:
+            first_elem = None
+        if first_elem is not None and isinstance(first_elem, Enum):
             indices = np.array(
                 [item.index for item in array], dtype=ENUM_ARRAY_DTYPE
             )


### PR DESCRIPTION
## Summary

Fixes #427

In pandas 3.0, string columns use `StringDtype` by default. When a pandas Series has a non-integer index (e.g., string index), `array[0]` does **label-based lookup** (looking for key `"0"`) instead of **positional access**, causing `KeyError: 0`.

This broke policyengine-us when enabling pandas 3.0 support - specifically the `county` variable tests failed with:

```
policyengine_core/enums/enum.py:69: in encode
    if len(array) > 0 and isinstance(array[0], Enum):
                                      ^^^^^^^^
E   KeyError: 0
```

## Changes

- Modified `Enum.encode()` to use `.iloc[0]` for pandas Series to ensure positional access
- Added two tests for encoding pandas Series containing Enum items:
  - `test_enum_encode_pandas_series_with_enum_items` - basic Series with default index
  - `test_enum_encode_pandas_series_with_string_index` - Series with string index (the failing case)

## Test plan

- [x] New tests pass locally
- [x] All existing enum tests pass
- [ ] CI passes

## Related

- policyengine-us pandas 3.0 PR (blocked by this): https://github.com/PolicyEngine/policyengine-us/pull/7233

🤖 Generated with [Claude Code](https://claude.com/claude-code)