### PR TITLE
Add pandas 2+3 CI matrix testing

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -35,6 +35,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
         python-version: [ "3.12", "3.13" ]
+        pandas-version: [ "2", "3" ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -52,6 +53,14 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install package
         run: make install
+      - name: Install pandas ${{ matrix.pandas-version }}
+        shell: bash
+        run: |
+          if [ "${{ matrix.pandas-version }}" = "2" ]; then
+            pip install "pandas>=2,<3"
+          else
+            pip install "pandas>=3,<4"
+          fi
       - name: Run tests
         run: make test
       - uses: codecov/codecov-action@v4

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    added:
+      - Added pandas 2 and 3 CI matrix testing to ensure compatibility with both major versions.


### PR DESCRIPTION
## Summary
- Adds `pandas-version: ["2", "3"]` to the CI test matrix in the `Test` job
- After installing dependencies, forces the specific pandas major version so tests run against both pandas 2.x and 3.x
- Ensures policyengine-core remains compatible with both pandas 2.x and 3.x
- Follows up on the recent pandas 3.0 compatibility fixes (#424, #428, #430)

## Test plan
- [ ] CI passes with pandas 2 matrix (ubuntu + windows, py3.12 + py3.13)
- [ ] CI passes with pandas 3 matrix (ubuntu + windows, py3.12 + py3.13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)