### PR TITLE
Add ruff check linting with E and F rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ documentation:
 
 format:
 	ruff format .
+	ruff check .
 
 install:
 	pip install -e ".[dev]" --config-settings editable_mode=compat

--- a/changelog.d/add-ruff-linting.added.md
+++ b/changelog.d/add-ruff-linting.added.md
@@ -1,0 +1,1 @@
+Added ruff check linting configuration with E and F rules to catch common Python errors.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,3 +103,7 @@ showcontent = true
 directory = "removed"
 name = "Removed"
 showcontent = true
+
+[tool.ruff.lint]
+select = ["E", "F"]
+ignore = ["E402", "E501", "E712", "E713", "E721", "E722", "E741", "F401", "F402", "F403", "F405", "F541", "F811", "F821", "F841"]


### PR DESCRIPTION
## Summary
- Adds `[tool.ruff.lint]` config to `pyproject.toml` selecting E (pycodestyle) and F (pyflakes) rules with a conservative ignore list
- Adds `ruff check .` to the Makefile `format` target (after `ruff format .`)
- Does NOT include "I" (isort) rules to avoid circular import issues
- No code changes -- config only

## Ignored rules
`E402`, `E501`, `E712`, `E713`, `E721`, `E722`, `E741`, `F401`, `F402`, `F403`, `F405`, `F541`, `F811`, `F821`, `F841`

## Test plan
- [x] `ruff check .` passes with the ignore list on current codebase

Generated with [Claude Code](https://claude.com/claude-code)