### PR TITLE
Migrate from pip to uv for dependency management

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -24,8 +24,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
       - name: Build changelog
-        run: pip install yaml-changelog>=0.1.7 && make changelog
+        run: uv pip install --system yaml-changelog>=0.1.7 && make changelog
       - name: Preview changelog update
         run: ".github/get-changelog-diff.sh"
       - name: Check version number has been properly updated
@@ -42,6 +44,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
       - name: Install package
         run: make install
       - name: Run tests

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -31,8 +31,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
       - name: Build changelog
-        run: pip install yaml-changelog && make changelog
+        run: uv pip install --system yaml-changelog && make changelog
       - name: Preview changelog update
         run: ".github/get-changelog-diff.sh"
       - name: Update changelog
@@ -57,6 +59,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
       - name: Install package
         run: make install
       - name: Run tests
@@ -83,6 +87,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
       - name: Publish a git tag
         run: ".github/publish-git-tag.sh || true"
       - name: Install package

--- a/Makefile
+++ b/Makefile
@@ -1,31 +1,31 @@
 all: install format test build changelog
 
 documentation:
-	jb clean docs
-	jb build docs
+	uv run jb clean docs
+	uv run jb build docs
 
 format:
-	black . -l 79
+	uv run black . -l 79
 
 install:
-	pip install -e .[dev]
+	uv pip install -e .[dev]
 
 test-country-template:
-	policyengine-core test policyengine_core/country_template/tests -c policyengine_core.country_template
+	uv run policyengine-core test policyengine_core/country_template/tests -c policyengine_core.country_template
 
 mypy:
-	mypy --config-file mypy.ini policyengine_core tests
+	uv run mypy --config-file mypy.ini policyengine_core tests
 
 test: test-country-template
-	coverage run -a --branch -m pytest tests --disable-pytest-warnings
-	coverage xml -i
+	uv run coverage run -a --branch -m pytest tests --disable-pytest-warnings
+	uv run coverage xml -i
 
 build:
-	python setup.py sdist bdist_wheel
+	uv run python setup.py sdist bdist_wheel
 
 changelog:
-	build-changelog changelog.yaml --output changelog.yaml --update-last-date --start-from 0.1.0 --append-file changelog_entry.yaml
-	build-changelog changelog.yaml --org PolicyEngine --repo policyengine-core --output CHANGELOG.md --template .github/changelog_template.md
-	bump-version changelog.yaml setup.py
+	uv run build-changelog changelog.yaml --output changelog.yaml --update-last-date --start-from 0.1.0 --append-file changelog_entry.yaml
+	uv run build-changelog changelog.yaml --org PolicyEngine --repo policyengine-core --output CHANGELOG.md --template .github/changelog_template.md
+	uv run bump-version changelog.yaml setup.py
 	rm changelog_entry.yaml || true
 	touch changelog_entry.yaml

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Migrate from pip to uv for dependency management.


### PR DESCRIPTION
## Summary
- Replace `pip install` with `uv pip install` in the Makefile
- Add `astral-sh/setup-uv@v3` action to all CI workflow jobs (pr.yaml and push.yaml)
- Prefix all Makefile tool invocations with `uv run` (pytest, coverage, black, jb, etc.)
- Add changelog entry

## Test plan
- [ ] CI passes on this PR (lint, test on ubuntu + windows, build, docs)
- [ ] Verify `make install` works locally with uv installed
- [ ] Verify `make test` runs tests correctly via `uv run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)