### PR TITLE
Fix non-reproducible numpy.random seeds from hash() of strings

### DIFF
--- a/changelog.d/fix-hash-seed-stability.fixed.md
+++ b/changelog.d/fix-hash-seed-stability.fixed.md
@@ -1,0 +1,1 @@
+Use a stable hash (SHA-256) when seeding ``numpy.random`` from situation inputs and variable names, so ``random()`` produces reproducible results across Python processes regardless of ``PYTHONHASHSEED``. Also sort keys when hashing situation inputs so equivalent situations built in different dict orders produce the same seed.

--- a/policyengine_core/simulations/simulation.py
+++ b/policyengine_core/simulations/simulation.py
@@ -1,3 +1,4 @@
+import hashlib
 import tempfile
 from typing import TYPE_CHECKING, Any, Dict, List, Type, Union
 
@@ -29,6 +30,18 @@ from policyengine_core.tools.google_cloud import (
 )
 
 import json
+
+
+def _stable_hash_to_seed(value: str) -> int:
+    """Deterministically hash a string to an int suitable for numpy.random.seed.
+
+    Python's built-in ``hash()`` is randomized per process (PYTHONHASHSEED) for
+    strings, which makes seeds derived from it non-reproducible across runs.
+    Use a stable cryptographic hash truncated to the seed range instead.
+    """
+    digest = hashlib.sha256(value.encode("utf-8")).digest()
+    return int.from_bytes(digest[:4], "big") % 1000000
+
 
 if TYPE_CHECKING:
     from policyengine_core.taxbenefitsystems import TaxBenefitSystem
@@ -203,8 +216,13 @@ class Simulation:
             if original_input.get("axes") is not None:
                 original_input["axes"] = {}
             # Hash the situation input to a random number, so situations with axes behave the
-            # same ways as the same situations without axes.
-            hashed_input = hash(json.dumps(original_input)) % 1000000
+            # same ways as the same situations without axes. ``sort_keys=True``
+            # keeps the hash stable across equivalent inputs built from differently
+            # ordered dicts, and ``_stable_hash_to_seed`` keeps it stable across
+            # Python processes (built-in ``hash`` is randomized per process).
+            hashed_input = _stable_hash_to_seed(
+                json.dumps(original_input, sort_keys=True)
+            )
             np.random.seed(hashed_input)
 
         if reform is not None:
@@ -462,7 +480,7 @@ class Simulation:
 
         self.tracer.record_calculation_start(variable_name, period, self.branch_name)
 
-        np.random.seed(hash(variable_name + str(period)) % 1000000)
+        np.random.seed(_stable_hash_to_seed(variable_name + str(period)))
 
         try:
             result = self._calculate(variable_name, period)

--- a/tests/core/test_stable_hash_seed.py
+++ b/tests/core/test_stable_hash_seed.py
@@ -1,0 +1,62 @@
+"""Regression tests for deterministic seeding in ``Simulation``.
+
+Python's built-in ``hash()`` is randomized per process for strings, so any seed
+derived from it changes from one ``python`` invocation to the next. This module
+ensures ``Simulation`` uses a stable hash so results involving ``random()`` are
+reproducible across runs (issue C6 in the 2026-04 bug hunt, related to #412).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import textwrap
+
+from policyengine_core.simulations.simulation import _stable_hash_to_seed
+
+
+def test_stable_hash_to_seed_is_deterministic_across_runs():
+    # Run a subprocess with the default PYTHONHASHSEED (which is randomized by
+    # default in CPython 3.3+). If the hash depended on the built-in ``hash()``
+    # over a string, the value would differ each run.
+    script = textwrap.dedent(
+        """
+        from policyengine_core.simulations.simulation import _stable_hash_to_seed
+        print(_stable_hash_to_seed("employment_income-2024"))
+        """
+    ).strip()
+    out_a = subprocess.run(
+        [sys.executable, "-c", script],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    out_b = subprocess.run(
+        [sys.executable, "-c", script],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    # Also compute the expected value in-process to assert stability in CI.
+    expected = str(_stable_hash_to_seed("employment_income-2024"))
+    assert out_a == out_b == expected
+
+
+def test_stable_hash_to_seed_covers_seed_range():
+    # numpy.random.seed accepts integers in [0, 2**32). Our output must be
+    # bounded (we truncate mod 1_000_000 to preserve compatibility with
+    # pre-existing seed ranges).
+    seed = _stable_hash_to_seed("variable_name-2024-01")
+    assert isinstance(seed, int)
+    assert 0 <= seed < 1_000_000
+
+
+def test_sort_keys_makes_equivalent_inputs_share_a_seed():
+    # Two equivalent situations constructed with different dict insertion order
+    # must produce the same hash / seed so calls to ``random()`` are stable.
+    a = {"person": {"you": {"employment_income": 1000, "age": 30}}}
+    b = {"person": {"you": {"age": 30, "employment_income": 1000}}}
+    seed_a = _stable_hash_to_seed(json.dumps(a, sort_keys=True))
+    seed_b = _stable_hash_to_seed(json.dumps(b, sort_keys=True))
+    assert seed_a == seed_b


### PR DESCRIPTION
## Summary

`Simulation` previously seeded `numpy.random` with the built-in `hash()` of strings — both for the situation-input hash (line 207) and for the per-variable/per-period seed (line 465). CPython randomizes string hashes per process via `PYTHONHASHSEED`, so any variable formula that calls `random(population)` produced different values every time the process restarted. This is exactly what issue #412 is concerned about, but this layer isn't called out there.

## Fix

- Introduce `_stable_hash_to_seed(value)` backed by `hashlib.sha256`, truncated to the same `% 1000000` range the old code used, so pre-existing seed distributions are preserved.
- Replace both `hash(...) % 1000000` call sites in `policyengine_core/simulations/simulation.py`.
- Also pass `sort_keys=True` when `json.dumps`-ing the situation input, so two equivalent situations built in different dict orders share a seed.

## Reproduction

```python
# Before: prints two different numbers
python -c 'print(hash("employment_income-2024") % 1000000)'
python -c 'print(hash("employment_income-2024") % 1000000)'

# After: stable across invocations
python -c 'from policyengine_core.simulations.simulation import _stable_hash_to_seed; print(_stable_hash_to_seed("employment_income-2024"))'
```

## Test plan

- [x] Added `tests/core/test_stable_hash_seed.py`:
  - runs the same hash in two fresh subprocesses and asserts equality (would fail if we still used `hash()`),
  - asserts the seed is within the documented range,
  - asserts equivalent situations with different dict order hash identically.
- [x] `uv run pytest tests/core/test_stable_hash_seed.py tests/core/test_simulations.py -x -q` passes locally.

Fixes C6 from the 2026-04 bug hunt.

Generated with [Claude Code](https://claude.com/claude-code).