### PR TITLE
Fix subtracts sign when element is a parameter

### DIFF
--- a/changelog.d/fix-subtracts-sign.fixed.md
+++ b/changelog.d/fix-subtracts-sign.fixed.md
@@ -1,0 +1,1 @@
+Correctly subtract parameter values when a ``subtracts`` list element refers to a parameter (previously the parameter value was added instead of subtracted, making the formula off by 2x the parameter value).

--- a/policyengine_core/simulations/simulation.py
+++ b/policyengine_core/simulations/simulation.py
@@ -946,7 +946,7 @@ class Simulation:
                                 self.tax_benefit_system.parameters,
                                 subtracted_variable,
                             )
-                            values = values + parameter(period.start)
+                            values = values - parameter(period.start)
                         except:
                             raise ValueError(
                                 f"In the variable '{variable.name}', the 'subtracts' attribute is a list that contains a string '{subtracted_variable}' that does not match any variable or parameter."

--- a/tests/core/variables/test_subtracts_sign.py
+++ b/tests/core/variables/test_subtracts_sign.py
@@ -1,0 +1,58 @@
+"""Regression test for ``subtracts`` with a parameter element (bug C5).
+
+The bug: when a ``subtracts`` list element refers to a parameter (not another
+variable), the simulation previously did ``values = values + parameter(...)``
+instead of subtracting it. That flipped the sign for any such entry, making
+the formula value off by 2x the parameter value.
+"""
+
+from __future__ import annotations
+
+from policyengine_core.entities import Entity
+from policyengine_core.model_api import ETERNITY, Variable
+from policyengine_core.parameters import Parameter, ParameterNode
+from policyengine_core.simulations import SimulationBuilder
+from policyengine_core.taxbenefitsystems import TaxBenefitSystem
+
+
+def _build_system_with_parameter_subtracts():
+    Person = Entity("person", "people", "Person", "A person")
+    system = TaxBenefitSystem([Person])
+
+    class base_income(Variable):
+        value_type = float
+        entity = Person
+        definition_period = ETERNITY
+        label = "Base income before subtraction"
+        default_value = 1000.0
+
+    class net_income(Variable):
+        value_type = float
+        entity = Person
+        definition_period = ETERNITY
+        label = "Net income"
+        adds = ["base_income"]
+        # ``fee`` is a parameter, NOT a variable; the simulation must subtract it.
+        subtracts = ["fee"]
+
+    system.add_variables(base_income, net_income)
+
+    # Attach a Parameter called ``fee`` worth 300 to the parameter tree.
+    if system.parameters is None:
+        system.parameters = ParameterNode("", data={})
+    fee = Parameter("fee", data={"2000-01-01": 300.0})
+    system.parameters.add_child("fee", fee)
+
+    return system
+
+
+def test_subtracts_with_parameter_actually_subtracts():
+    system = _build_system_with_parameter_subtracts()
+    simulation = SimulationBuilder().build_from_dict(
+        system,
+        {"people": {"person": {}}},
+    )
+    value = simulation.calculate("net_income", "2024")
+    # base_income defaults to 1000; fee is 300. net_income must be 700.
+    # Before the fix, it was 1000 + 300 = 1300 (off by 2 * 300).
+    assert value[0] == 700.0


### PR DESCRIPTION
## Summary

When a `Variable.subtracts` list contains a parameter name (not another variable name), `Simulation._run_formula` was doing `values = values + parameter(period.start)` — adding instead of subtracting. Any variable whose `subtracts` list references a parameter ends up off by 2x that parameter's value.

## Fix

One-character fix at `policyengine_core/simulations/simulation.py:949`: `+` -> `-`.

## Reproduction

```python
class net_income(Variable):
    adds = [\"base_income\"]       # defaults to 1000
    subtracts = [\"fee\"]          # parameter worth 300
# Before: simulation.calculate(\"net_income\") returns 1300
# After:  simulation.calculate(\"net_income\") returns 700
```

## Test plan

- [x] Added `tests/core/variables/test_subtracts_sign.py` — builds a variable whose `subtracts` references a parameter and asserts the subtraction actually happens.
- [x] Verified the new test fails on `upstream/master` before the fix and passes after.
- [x] `uv run pytest tests/core/variables/ -x -q` passes locally.

Fixes C5 from the 2026-04 bug hunt.

Generated with [Claude Code](https://claude.com/claude-code).