### PR TITLE
Invalidate caches after Simulation.apply_reform

### DIFF
--- a/changelog.d/fix-apply-reform-cache-invalidation.fixed.md
+++ b/changelog.d/fix-apply-reform-cache-invalidation.fixed.md
@@ -1,0 +1,1 @@
+``Simulation.apply_reform`` now invalidates every cached value (``_fast_cache``, in-memory holder storage, on-disk holder storage, ``invalidated_caches``) and cascades the invalidation into every branch. Previously those caches still contained pre-reform values, so subsequent ``calculate`` calls returned stale values even though the tax-benefit system had been mutated.

--- a/policyengine_core/simulations/simulation.py
+++ b/policyengine_core/simulations/simulation.py
@@ -225,6 +225,33 @@ class Simulation:
             if isinstance(reform, dict):
                 reform = Reform.from_dict(reform)
             reform.apply(self.tax_benefit_system)
+        # Invalidate every cached value so the simulation recomputes under
+        # the new tax-benefit system. Previously ``apply_reform`` left
+        # ``_fast_cache``, in-memory holder storage, and on-disk holder
+        # storage populated with pre-reform values, so the next
+        # ``calculate`` call returned stale values (bug H3).
+        self._invalidate_all_caches()
+
+    def _invalidate_all_caches(self) -> None:
+        """Purge every cached calculation on this simulation.
+
+        Called after ``apply_reform`` and any other operation that changes
+        the tax-benefit system underneath an already-calculated simulation.
+        Also cascades into any branches created via ``get_branch`` so those
+        don't keep returning stale pre-reform values either.
+        """
+        self._fast_cache = {}
+        self.invalidated_caches = set()
+        for variable in list(self.tax_benefit_system.variables):
+            holder = self.get_holder(variable)
+            # ``Holder.delete_arrays`` with ``period=None`` wipes every
+            # period on both memory and disk storage. After the storage-delete
+            # bug fix (C2) that now respects branch_name, so wipe both.
+            holder._memory_storage._arrays = {}
+            if holder._disk_storage is not None:
+                holder._disk_storage._files = {}
+        for branch in self.branches.values():
+            branch._invalidate_all_caches()
 
     def build_from_populations(self, populations: Dict[str, Population]) -> None:
         """This method of initialisation requires the populations to be pre-initialised.

--- a/tests/core/test_apply_reform_invalidates_cache.py
+++ b/tests/core/test_apply_reform_invalidates_cache.py
@@ -1,0 +1,38 @@
+"""Regression test: ``Simulation.apply_reform`` must invalidate caches (H3).
+
+Before this fix, ``sim.apply_reform(r)`` left the in-memory holder storage,
+the ``_fast_cache`` and the on-disk storage populated with the pre-reform
+values. Subsequent calls to ``calculate`` returned stale data.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from policyengine_core.model_api import Reform
+from policyengine_core.country_template import situation_examples
+from policyengine_core.simulations import SimulationBuilder
+
+
+def test_apply_reform_invalidates_holder_cache(tax_benefit_system):
+    sim = SimulationBuilder().build_from_entities(
+        tax_benefit_system, situation_examples.single
+    )
+    period = "2017-01"
+
+    before_reform = sim.calculate("basic_income", period=period)
+    assert before_reform[0] > 0
+
+    class NeutraliseBasicIncome(Reform):
+        def apply(self):
+            self.neutralize_variable("basic_income")
+
+    sim.apply_reform(NeutraliseBasicIncome)
+
+    after_reform = sim.calculate("basic_income", period=period)
+    # After neutralisation the variable must return 0 regardless of cached
+    # pre-reform values.
+    assert after_reform[0] == 0, (
+        f"apply_reform left stale cache values for basic_income; got "
+        f"{after_reform[0]} instead of 0."
+    )


### PR DESCRIPTION
## Summary

``Simulation.apply_reform`` mutated the tax-benefit system in place but left every calculation cache populated with pre-reform values. After ``sim.calculate(...)`` and then ``sim.apply_reform(r)``, the next ``calculate`` call returned stale pre-reform values because the relevant ``_fast_cache``, in-memory holder storage, and on-disk holder storage were all still populated.

## Fix

After applying the reform, purge:
- ``_fast_cache``
- ``invalidated_caches``
- every holder's in-memory ``_arrays``
- every holder's on-disk ``_files``

Cascade the same invalidation into any branches already created via ``get_branch``.

## Reproduction

```python
sim = SimulationBuilder().build_from_entities(tbs, single)
before = sim.calculate(\"basic_income\", \"2017-01\")  # 600
sim.apply_reform(NeutraliseBasicIncome)
after = sim.calculate(\"basic_income\", \"2017-01\")
# Before this fix: 600 (stale).
# After:            0 (correct).
```

## Test plan

- [x] Added ``tests/core/test_apply_reform_invalidates_cache.py``:
  calculates, applies a reform that neutralises the variable, and asserts the
  next calculation reflects the reform.
- [x] Verified the new test fails on ``upstream/master`` before the fix.
- [x] ``uv run pytest tests/core/test_reforms.py tests/core/test_simulations.py tests/core/test_holders.py tests/core/test_parameters.py -x -q`` — 47 passed.

Fixes H3 from the 2026-04 bug hunt.

Generated with [Claude Code](https://claude.com/claude-code).