### PR TITLE
Pass minlength=self.count to numpy.bincount in group population

### DIFF
--- a/changelog.d/fix-bincount-minlength.fixed.md
+++ b/changelog.d/fix-bincount-minlength.fixed.md
@@ -1,0 +1,1 @@
+Pass ``minlength=self.count`` to ``numpy.bincount`` in ``GroupPopulation.sum`` (no-role branch) and ``GroupPopulation.nb_persons`` (no-role branch) so the result always has one cell per entity. Previously, when the highest-indexed entity had zero members, ``bincount`` returned a shorter array that silently misaligned downstream broadcasting.

--- a/policyengine_core/populations/group_population.py
+++ b/policyengine_core/populations/group_population.py
@@ -131,7 +131,13 @@ class GroupPopulation(Population):
                 minlength=self.count,
             )
         else:
-            return numpy.bincount(self.members_entity_id, weights=array)
+            # Pass ``minlength=self.count`` so the result has one cell per
+            # entity even when the highest-indexed entity has zero members.
+            # Without it, ``bincount`` returns a shorter array that
+            # misaligns downstream broadcasting (bug H4).
+            return numpy.bincount(
+                self.members_entity_id, weights=array, minlength=self.count
+            )
 
     @projectors.projectable
     def any(self, array: ArrayLike, role: Role = None) -> ArrayLike:
@@ -260,7 +266,10 @@ class GroupPopulation(Population):
                 role_condition = self.members_role == role
             return self.sum(role_condition)
         else:
-            return numpy.bincount(self.members_entity_id)
+            # ``minlength=self.count`` ensures the returned array has one
+            # cell per entity even when the highest-indexed entity has
+            # zero members (bug H4).
+            return numpy.bincount(self.members_entity_id, minlength=self.count)
 
     # Projection person -> entity
 

--- a/tests/core/test_bincount_minlength.py
+++ b/tests/core/test_bincount_minlength.py
@@ -1,0 +1,54 @@
+"""Regression tests for GroupPopulation.sum / .nb_persons with empty last entity (H4).
+
+When the highest-indexed entity has zero members, ``numpy.bincount`` without
+``minlength`` returns an array shorter than the number of entities, which
+silently misaligns downstream broadcasting. Both the role-less ``sum`` branch
+and ``nb_persons`` without a role were missing ``minlength``.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+import numpy
+
+from policyengine_core.simulations import SimulationBuilder
+
+
+def test_sum_when_last_entity_has_no_members(tax_benefit_system):
+    """A household with no persons must still appear in ``sum`` output."""
+    persons_ids: Iterable = [1, 2, 3]
+    # Three households exist, but only the first two have persons.
+    households_ids: Iterable = ["a", "b", "c"]
+    persons_households: Iterable = ["a", "a", "b"]
+
+    builder = SimulationBuilder()
+    builder.create_entities(tax_benefit_system)
+    builder.declare_person_entity("person", persons_ids)
+    household = builder.declare_entity("household", households_ids)
+    builder.join_with_persons(household, persons_households, ["first_parent"] * 3)
+
+    # ``sum`` (no role): the last household (index 2) has no members, so
+    # ``numpy.bincount(...)`` without ``minlength`` would return a length-2
+    # array and break broadcasting against the 3-element entity array.
+    result = household.sum(numpy.asarray([1.0, 1.0, 1.0]))
+    assert len(result) == household.count == 3
+    assert result.tolist() == [2.0, 1.0, 0.0]
+
+
+def test_nb_persons_when_last_entity_has_no_members(tax_benefit_system):
+    persons_ids: Iterable = [1, 2, 3]
+    households_ids: Iterable = ["a", "b", "c"]
+    persons_households: Iterable = ["a", "a", "b"]
+
+    builder = SimulationBuilder()
+    builder.create_entities(tax_benefit_system)
+    builder.declare_person_entity("person", persons_ids)
+    household = builder.declare_entity("household", households_ids)
+    builder.join_with_persons(household, persons_households, ["first_parent"] * 3)
+
+    # ``nb_persons`` without a role goes through the no-role branch of
+    # ``bincount`` on line 263.
+    counts = household.nb_persons()
+    assert len(counts) == household.count == 3
+    assert counts.tolist() == [2, 1, 0]


### PR DESCRIPTION
## Summary

Two call sites in ``GroupPopulation`` call ``numpy.bincount`` without ``minlength``:

- ``GroupPopulation.sum`` when no role is provided (line 134)
- ``GroupPopulation.nb_persons`` when no role is provided (line 263)

If the highest-indexed entity has zero members, ``bincount`` returns an array shorter than ``self.count``, which silently misaligns downstream broadcasting across entities. The role-guarded ``sum`` branch already passed ``minlength=self.count``; the other two were missing it.

## Fix

Pass ``minlength=self.count`` to both.

## Test plan

- [x] Added ``tests/core/test_bincount_minlength.py`` — builds three households where the last one has no members, and asserts both ``sum`` and ``nb_persons`` return length-3 arrays.
- [x] Verified the new tests fail on ``upstream/master`` before the fix.
- [x] ``uv run pytest tests/core/test_simulation_builder.py tests/core/test_projectors.py tests/core/test_entities.py -x -q`` — 64 passed.

Fixes H4 from the 2026-04 bug hunt.

Generated with [Claude Code](https://claude.com/claude-code).