### PR TITLE
Key test_runner TBS cache on baseline object, not id()

### DIFF
--- a/changelog.d/fix-tbs-cache-identity.fixed.md
+++ b/changelog.d/fix-tbs-cache-identity.fixed.md
@@ -1,0 +1,1 @@
+Key ``_tax_benefit_system_cache`` in ``policyengine_core.tools.test_runner`` on the baseline object itself (via ``weakref.WeakKeyDictionary``) instead of ``id(baseline)``. CPython reuses object ids after GC, so a collected baseline could hit a stale cache entry belonging to a completely different TBS, silently sharing test setup across unrelated baselines.

--- a/policyengine_core/tools/test_runner.py
+++ b/policyengine_core/tools/test_runner.py
@@ -61,7 +61,14 @@ TEST_KEYWORDS = {
 
 yaml, Loader = import_yaml()
 
-_tax_benefit_system_cache: Dict = {}
+# Key the cache on the baseline object itself (via ``WeakKeyDictionary``) so
+# that when a baseline is garbage-collected its cache entries disappear with
+# it. Previously the cache was keyed on ``id(baseline)``, which Python
+# reuses after GC — a collected baseline could produce the same id as a
+# completely unrelated new baseline and hit a stale cache entry (bug H9).
+import weakref
+
+_tax_benefit_system_cache: "weakref.WeakKeyDictionary" = weakref.WeakKeyDictionary()
 
 
 def run_tests(tax_benefit_system, paths, options=None):
@@ -410,17 +417,19 @@ def _get_tax_benefit_system(
     if not isinstance(extensions, list):
         extensions = [extensions]
 
-    # keep reforms order in cache, ignore extensions order
-    key = hash(
-        (
-            id(baseline),
-            ":".join([reform if isinstance(reform, str) else "" for reform in reforms]),
-            reform_key,
-            frozenset(extensions),
-        )
+    # Inner key is (reforms in order, reform_key, extensions as a frozenset).
+    # The outer cache is keyed on the baseline *object* so its entries are
+    # tied to the baseline's lifetime (see bug H9 above).
+    inner_key = (
+        ":".join([reform if isinstance(reform, str) else "" for reform in reforms]),
+        reform_key,
+        frozenset(extensions),
     )
-    if _tax_benefit_system_cache.get(key):
-        return _tax_benefit_system_cache.get(key)
+    baseline_entry = _tax_benefit_system_cache.get(baseline)
+    if baseline_entry is not None:
+        cached = baseline_entry.get(inner_key)
+        if cached is not None:
+            return cached
 
     current_tax_benefit_system = baseline.clone()
 
@@ -437,7 +446,10 @@ def _get_tax_benefit_system(
         current_tax_benefit_system = current_tax_benefit_system.clone()
         current_tax_benefit_system.load_extension(extension)
 
-    _tax_benefit_system_cache[key] = current_tax_benefit_system
+    if baseline_entry is None:
+        baseline_entry = {}
+        _tax_benefit_system_cache[baseline] = baseline_entry
+    baseline_entry[inner_key] = current_tax_benefit_system
 
     return current_tax_benefit_system
 

--- a/tests/core/test_tax_benefit_system_cache_identity.py
+++ b/tests/core/test_tax_benefit_system_cache_identity.py
@@ -1,0 +1,50 @@
+"""Regression test: test_runner cache must tie entries to the baseline's lifetime (H9).
+
+Previously ``_tax_benefit_system_cache`` was keyed on ``id(baseline)``, which
+CPython reuses after GC. A baseline that had been collected and replaced
+could hit a stale cache entry belonging to a completely different TBS,
+silently sharing test setup across unrelated baselines and running
+parametric reforms against the wrong baseline.
+"""
+
+from __future__ import annotations
+
+import gc
+import weakref
+
+from policyengine_core.country_template import CountryTaxBenefitSystem
+from policyengine_core.tools.test_runner import (
+    _get_tax_benefit_system,
+    _tax_benefit_system_cache,
+)
+
+
+def test_cache_entry_is_released_when_baseline_is_collected():
+    baseline = CountryTaxBenefitSystem()
+    ref = weakref.ref(baseline)
+    _get_tax_benefit_system(baseline, [], [])
+    # Cache must now contain an entry for this baseline.
+    assert baseline in _tax_benefit_system_cache
+
+    # Drop the strong reference and force GC.
+    del baseline
+    gc.collect()
+
+    # The WeakKeyDictionary must have dropped the entry, and the baseline
+    # should be fully collected (no stale cache entries keeping it alive,
+    # no id-reuse attack surface).
+    assert ref() is None, "baseline should be garbage-collected"
+    # Old behaviour (id-based cache): entry persists past baseline
+    # collection and can collide with a reused id.
+    assert len(list(_tax_benefit_system_cache.keys())) == 0 or all(
+        ref() is not key for key in _tax_benefit_system_cache.keys()
+    )
+
+
+def test_two_distinct_baselines_do_not_share_cache_entries():
+    baseline_a = CountryTaxBenefitSystem()
+    baseline_b = CountryTaxBenefitSystem()
+    tbs_a = _get_tax_benefit_system(baseline_a, [], [])
+    tbs_b = _get_tax_benefit_system(baseline_b, [], [])
+    # Each baseline must get its own clone, not a cache hit from the other.
+    assert tbs_a is not tbs_b


### PR DESCRIPTION
## Summary

The YAML test runner cached built ``TaxBenefitSystem`` instances keyed on ``hash((id(baseline), reforms, reform_key, extensions))``. CPython reuses object ids after GC, so a baseline that had been collected and replaced could hit a stale cache entry belonging to a completely different ``TaxBenefitSystem``. Test isolation silently leaked, and parametric reforms could run against the wrong baseline.

## Fix

Switch the outer cache to a ``WeakKeyDictionary`` keyed on the baseline itself. Cache entries are now tied to the baseline's lifetime and drop automatically when the baseline is collected. The inner (reforms, reform_key, extensions) key is kept as a plain dict under each weakly-held baseline entry.

## Test plan

- [x] Added ``tests/core/test_tax_benefit_system_cache_identity.py``:
  - populate cache, drop the strong reference, run GC, confirm both the baseline and its cache entry are gone;
  - two distinct baselines each receive their own cached clone.
- [x] ``uv run pytest tests/core/tools -x -q`` — 37 passed.

Fixes H9 from the 2026-04 bug hunt.

Generated with [Claude Code](https://claude.com/claude-code).