### PR TITLE
Raise clear error on ETERNITY.get_subperiods

### DIFF
--- a/changelog.d/fix-eternity-get-subperiods.fixed.md
+++ b/changelog.d/fix-eternity-get-subperiods.fixed.md
@@ -1,0 +1,1 @@
+Raise a descriptive ``ValueError`` when calling ``Period.get_subperiods`` on an ``ETERNITY`` period. Previously the call crashed with ``TypeError: 'float' object cannot be interpreted as an integer`` because ``size`` is ``float("inf")`` for ETERNITY periods, and the YEAR subperiod branch passed it straight to ``range(...)``.

--- a/policyengine_core/periods/period_.py
+++ b/policyengine_core/periods/period_.py
@@ -188,6 +188,15 @@ class Period(tuple):
         >>> period('year:2014:2').get_subperiods(YEAR)
         >>> [period('2014'), period('2015')]
         """
+        if self.unit == config.ETERNITY:
+            # ``ETERNITY`` periods carry ``size=float("inf")``; any attempt
+            # to build ``range(self.size)`` below would crash with a
+            # cryptic ``TypeError: 'float' object cannot be interpreted as
+            # an integer``. Fail fast with a clear message instead (bug H7).
+            raise ValueError(
+                "ETERNITY periods cannot be subdivided into finite periods."
+            )
+
         if helpers.unit_weight(self.unit) < helpers.unit_weight(unit):
             raise ValueError("Cannot subdivide {0} into {1}".format(self.unit, unit))
 

--- a/tests/core/test_eternity_subperiods.py
+++ b/tests/core/test_eternity_subperiods.py
@@ -1,0 +1,27 @@
+"""Regression test: ``period.get_subperiods`` on ETERNITY gives a clear error (H7).
+
+ETERNITY periods carry ``size=float("inf")``. ``get_subperiods`` previously
+did ``range(self.size)`` / ``range(self.size_in_months)`` without checking,
+so any code that called ``eternity_period.get_subperiods(...)`` crashed with
+``TypeError: 'float' object cannot be interpreted as an integer``.
+
+Fail fast with a descriptive ``ValueError`` instead.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from policyengine_core import periods
+
+
+def test_eternity_get_subperiods_raises_value_error():
+    eternity = periods.period(periods.ETERNITY)
+    with pytest.raises(ValueError, match="ETERNITY"):
+        eternity.get_subperiods(periods.MONTH)
+
+
+def test_eternity_get_subperiods_raises_value_error_for_year():
+    eternity = periods.period(periods.ETERNITY)
+    with pytest.raises(ValueError, match="ETERNITY"):
+        eternity.get_subperiods(periods.YEAR)


### PR DESCRIPTION
## Summary

``ETERNITY`` periods carry ``size=float(\"inf\")`` (set in ``helpers.period``). ``Period.get_subperiods`` then did ``range(self.size)`` / ``range(self.size_in_months)`` unconditionally, so any code that tried to subdivide an ETERNITY period crashed with:

```
TypeError: 'float' object cannot be interpreted as an integer
```

The MONTH/DAY branches happened to raise a separate error via ``size_in_months`` / ``size_in_days``, but the YEAR branch surfaced the raw ``TypeError`` directly.

## Fix

Fail fast with a descriptive ``ValueError`` before any ``range()`` call is attempted.

## Test plan

- [x] Added ``tests/core/test_eternity_subperiods.py`` asserting both MONTH and YEAR paths raise ``ValueError`` mentioning ``ETERNITY``.
- [x] Verified the YEAR test reproduces the original ``TypeError`` on master before the fix.
- [x] ``uv run pytest tests/core/test_periods.py tests/core/test_simulations.py -x -q`` — 46 passed.

Fixes H7 from the 2026-04 bug hunt.

Generated with [Claude Code](https://claude.com/claude-code).