### PR TITLE
Fix invalid YAML in push workflow

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -23,7 +23,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-        with:          token: ${{ secrets.POLICYENGINE_GITHUB }}
+        with:
+          token: ${{ secrets.POLICYENGINE_GITHUB }}
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/changelog.d/fix-push-workflow.fixed.md
+++ b/changelog.d/fix-push-workflow.fixed.md
@@ -1,0 +1,1 @@
+Fix invalid YAML in push workflow (`with:` and `token:` on the same line) that was causing all post-merge runs to fail with zero jobs, blocking version bumps and PyPI publishes.


### PR DESCRIPTION
## Summary

`.github/workflows/push.yaml:26` had `with:` and `token:` on the same line:

```yaml
        with:          token: ${{ secrets.POLICYENGINE_GITHUB }}
```

This is invalid YAML (`mapping values are not allowed here`). GitHub Actions has been silently rejecting the entire workflow on every merge commit for at least the last 10 PRs — `gh run list --workflow push.yaml` shows all runs as `failure` with 0 jobs.

Consequence: the `versioning` job (which runs towncrier + `bump_version.py` and pushes the `Update PolicyEngine Core` commit that triggers `Test` and `Publish`) never runs, so no version has been published to PyPI since this bug landed. Latest on PyPI is still **3.23.6**, despite many merged PRs including #454 (Python 3.9 support).

## Fix

Split the mapping onto two lines:

```yaml
        with:
          token: ${{ secrets.POLICYENGINE_GITHUB }}
```

Verified with `yaml.safe_load` — file now parses, `versioning.steps[0]` resolves correctly.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/push.yaml'))"` passes
- [ ] After merge, the push workflow should actually run. If so, the `versioning` job will bump the pending changelog entries (from #454 through this PR) and produce an `Update PolicyEngine Core` commit, which in turn triggers `Test` + `Publish` → PyPI will receive the long-backlog of versions.
