### PR TITLE
Mint GitHub App token in versioning job

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -21,10 +21,17 @@ jobs:
       && !(github.event.head_commit.message == 'Update PolicyEngine Core')
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.POLICYENGINE_GITHUB }}
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -45,6 +52,8 @@ jobs:
           committer_name: Github Actions[bot]
           author_name: Github Actions[bot]
           message: Update PolicyEngine Core
+          github_token: ${{ steps.app-token.outputs.token }}
+          fetch: false
   Test:
     runs-on: ubuntu-latest
     if: |

--- a/changelog.d/migrate-to-app-token.fixed.md
+++ b/changelog.d/migrate-to-app-token.fixed.md
@@ -1,0 +1,1 @@
+Migrate push workflow to use GitHub App token (APP_ID / APP_PRIVATE_KEY) instead of the expired `POLICYENGINE_GITHUB` PAT, so the `versioning` job can push the "Update PolicyEngine Core" commit that triggers Test + Publish. Matches the pattern already used by policyengine-us, policyengine-api, and several other PolicyEngine repos.


### PR DESCRIPTION
## Summary

The `POLICYENGINE_GITHUB` PAT referenced by `.github/workflows/push.yaml`'s checkout and `add-and-commit` steps has expired. Symptom: after #469 fixed the invalid YAML that had been silently killing the whole workflow, the `versioning` job now runs but fails at the `Checkout repo` step with:

```
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

which is what a checkout does when the `token:` input is an empty string.

## Fix

Swap the PAT for a short-lived GitHub App token minted via `actions/create-github-app-token@v1`, using the org-level `APP_ID` / `APP_PRIVATE_KEY` secrets that are already set and used by several sibling repos (`policyengine-us`, `policyengine-api`, `policyengine-uk-data`, `policyengine-household-api`, `policyengine-api-v2-alpha`). Pattern copied verbatim from `policyengine-us/.github/workflows/push.yaml`.

Benefits over renewing the PAT:
- No annual expiry to chase
- Not tied to any one person's account
- Narrower principle-of-least-privilege scope

Pushes by an App token still trigger downstream workflows (unlike `GITHUB_TOKEN` pushes), which is required here so the committed `Update PolicyEngine Core` commit can fire `Test` and `Publish`.

## Test plan

- [x] `yaml.safe_load` confirms the workflow still parses
- [ ] After merge: `versioning` job completes, produces an `Update PolicyEngine Core` commit; `Test` + `Publish` then run; PyPI receives the backlog (3.23.6 → 3.24.x with Python 3.9 support from #454)
