### PR TITLE
Add clear_parent_cache and mark_as_modified to ParameterScale

### DIFF
--- a/changelog.d/fix-scale-clear-parent-cache.fixed.md
+++ b/changelog.d/fix-scale-clear-parent-cache.fixed.md
@@ -1,0 +1,1 @@
+Add `clear_parent_cache` and `mark_as_modified` to `ParameterScale` so `Parameter.update()` no longer raises `AttributeError` when backdating parameters that live inside a scale bracket. Regression surfaced by `policyengine_uk.backdate_parameters(... "2015-01-01")` after the `_fast_cache` work in #448/#436.

--- a/policyengine_core/parameters/parameter_scale.py
+++ b/policyengine_core/parameters/parameter_scale.py
@@ -101,6 +101,19 @@ class ParameterScale(AtInstantLike):
             yield bracket
             yield from bracket.get_descendants()
 
+    def clear_parent_cache(self):
+        # ParameterScale itself caches nothing, but it sits between a
+        # Parameter (inside a ParameterScaleBracket) and the surrounding
+        # ParameterNode, so Parameter.update()'s recursive cache-clear has
+        # to pass through it. Propagate upward.
+        if getattr(self, "parent", None) is not None:
+            self.parent.clear_parent_cache()
+
+    def mark_as_modified(self):
+        self.modified = True
+        if getattr(self, "parent", None) is not None:
+            self.parent.mark_as_modified()
+
     def clone(self) -> "ParameterScale":
         clone = commons.empty_clone(self)
         clone.__dict__ = self.__dict__.copy()


### PR DESCRIPTION
## Summary

`Parameter.update()` (line 210) unconditionally calls `self.parent.clear_parent_cache()` and `self.parent.mark_as_modified()`. When the parameter lives inside a scale bracket, the parent chain is:

```
Parameter
  └─ ParameterScaleBracket  (is a ParameterNode → has the methods)
       └─ ParameterScale     (missing both methods!)
             └─ ParameterNode (has the methods)
```

When `ParameterScaleBracket.clear_parent_cache()` recurses into `self.parent.clear_parent_cache()`, it hits the `ParameterScale` (no method) and raises:

```
AttributeError: 'ParameterScale' object has no attribute 'clear_parent_cache'
```

This breaks `policyengine_uk.backdate_parameters(..., "2015-01-01")` at import time (and any other code path that reforms or updates a scale-hosted parameter). The bug was masked before the `_fast_cache` work in #436 / #448 because the call path wasn't as eager; it surfaces whenever `Parameter.update` actually fires.

## Fix

Add minimal `clear_parent_cache` and `mark_as_modified` methods to `ParameterScale` that just forward to its own parent (which is always a `ParameterNode` and has the real implementations). `ParameterScale` itself doesn't cache anything at this layer, so there's no local state to clear.

## Test plan

- [x] Local reproducer: `from policyengine_uk import Microsimulation` no longer hits the AttributeError (tested on both 3.9 and 3.14 venvs)
- [ ] CI: Test matrix on this PR should confirm no regression
- [ ] After merge + publish: `policyengine-uk` PR https://github.com/PolicyEngine/policyengine-uk/pull/1625 smoke-imports will resolve to the new core and pass
