### PR TITLE
Update GitHub Actions for Node 24 runtime

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -6,16 +6,16 @@ jobs:
   Lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
       - name: Check formatting
         run: uvx ruff format --check .
   check-changelog:
     name: Check changelog fragment
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Check for changelog fragment
         run: |
           FRAGMENTS=$(find changelog.d -type f ! -name '.gitkeep' | wc -l)
@@ -34,7 +34,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Enable long paths in Git (Windows only)
         if: runner.os == 'Windows'
         run: git config --system core.longpaths true
@@ -42,16 +42,16 @@ jobs:
         if: runner.os == 'Windows'
         run: reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem" /v LongPathsEnabled /t REG_DWORD /d 1 /f
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
       - name: Install package
         run: make install
       - name: Run tests
         run: make test
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v6
       - name: Build package
         run: make build
       - name: Test documentation builds
@@ -67,13 +67,13 @@ jobs:
         python-version: ['3.11', '3.12', '3.13', '3.14']
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
       - name: Install -core package
         run: |
           uv pip install --system .

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -9,9 +9,9 @@ jobs:
       (github.repository == 'PolicyEngine/policyengine-core')
       && (github.event.head_commit.message == 'Update PolicyEngine Core')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
       - name: Check formatting
         run: uvx ruff format --check .
   versioning:
@@ -23,21 +23,21 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
       - name: Build changelog
         run: |
           uv pip install --system towncrier
@@ -46,7 +46,7 @@ jobs:
       - name: Preview changelog update
         run: ".github/get-changelog-diff.sh"
       - name: Update changelog
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@v10
         with:
           add: "."
           committer_name: Github Actions[bot]
@@ -61,23 +61,23 @@ jobs:
       && (github.event.head_commit.message == 'Update PolicyEngine Core')
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
       - name: Install package
         run: make install
       - name: Run tests
         run: make test
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v6
       - name: Generate documentation
         run: make documentation
       - name: Deploy documentation
         if: matrix.os == 'ubuntu-latest'
-        uses: JamesIves/github-pages-deploy-action@releases/v3
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages # The branch the action should deploy to.
@@ -89,13 +89,13 @@ jobs:
       && (github.event.head_commit.message == 'Update PolicyEngine Core')
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
       - name: Publish a git tag
         run: ".github/publish-git-tag.sh || true"
       - name: Install package

--- a/changelog.d/update-actions-node24.changed.md
+++ b/changelog.d/update-actions-node24.changed.md
@@ -1,0 +1,1 @@
+Updated GitHub Actions workflows for Node 24-compatible action runtimes.


### PR DESCRIPTION
Updates GitHub Actions workflow action versions to releases that run on Node.js 24, removing Node.js 20 JavaScript action deprecation warnings before GitHub-hosted runners switch defaults on June 2, 2026.

This is a mechanical workflow-only change from an org-wide scan. It also updates older checkout/setup/action versions that still advertised Node.js 12 or 16 runtimes where a Node.js 24 successor is available.