### PR TITLE
Add runtime metadata for bundle validation

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -25,6 +25,25 @@ jobs:
             echo "Types: added, changed, fixed, removed, breaking"
             exit 1
           fi
+  BundleMetadataContract:
+    name: Validate bundle metadata contract
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+      - name: Install core
+        run: uv pip install --system .
+      - name: Install bundle validation tooling
+        # Pin the test-only bundle contract dependency until policyengine-bundles
+        # has published releases suitable for ordinary dependency specifiers.
+        run: uv pip install --system "policyengine-bundles @ git+https://github.com/PolicyEngine/policyengine-bundles@8ae9f56fefcf89f69b8a7e3bc49928509c6207be"
+      - name: Validate runtime metadata contract
+        run: python -m pytest tests/core/test_build_metadata.py
   Test:
     strategy:
       matrix:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: "3.14"
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
       - name: Install core

--- a/changelog.d/add-runtime-metadata.added.md
+++ b/changelog.d/add-runtime-metadata.added.md
@@ -1,0 +1,1 @@
+Added dependency-free runtime metadata for bundle validation.

--- a/policyengine_core/__init__.py
+++ b/policyengine_core/__init__.py
@@ -1,2 +1,3 @@
+from policyengine_core.build_metadata import get_runtime_metadata
 from policyengine_core.simulations import Microsimulation, Simulation
 from policyengine_core.taxbenefitsystems import TaxBenefitSystem

--- a/policyengine_core/build_metadata.py
+++ b/policyengine_core/build_metadata.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import importlib.metadata
+import json
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+PACKAGE_NAME = "policyengine-core"
+_PACKAGE_DIR = Path(__file__).resolve().parent
+
+__all__ = ["get_runtime_metadata"]
+
+
+def get_runtime_metadata() -> Dict[str, Any]:
+    """Return JSON-compatible metadata describing this core runtime.
+
+    The payload intentionally avoids importing the bundle orchestrator. It is
+    shaped to be validated by policyengine-bundles when that package is
+    available in release or integration-test workflows.
+    """
+
+    distribution = _get_distribution()
+    metadata: Dict[str, Any] = {
+        "name": PACKAGE_NAME,
+        "version": _get_package_version(distribution),
+    }
+
+    git_sha = _get_direct_url_git_sha(distribution) or _get_local_git_sha()
+    if git_sha is not None:
+        metadata["git_sha"] = git_sha
+
+    source_path = _get_source_path()
+    if source_path is not None:
+        metadata["source_path"] = source_path
+
+    return metadata
+
+
+def _get_distribution() -> Optional[importlib.metadata.Distribution]:
+    try:
+        return importlib.metadata.distribution(PACKAGE_NAME)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def _get_package_version(
+    distribution: Optional[importlib.metadata.Distribution],
+) -> str:
+    if distribution is not None:
+        return distribution.version
+
+    version = _get_pyproject_version()
+    if version is not None:
+        return version
+
+    raise importlib.metadata.PackageNotFoundError(PACKAGE_NAME)
+
+
+def _get_pyproject_version() -> Optional[str]:
+    git_root = _find_git_root(_PACKAGE_DIR)
+    if git_root is None:
+        return None
+
+    pyproject_path = git_root / "pyproject.toml"
+    if not pyproject_path.exists():
+        return None
+
+    for line in pyproject_path.read_text().splitlines():
+        stripped = line.strip()
+        if stripped.startswith("version = "):
+            return stripped.split("=", 1)[1].strip().strip('"')
+
+    return None
+
+
+def _get_direct_url_git_sha(
+    distribution: Optional[importlib.metadata.Distribution],
+) -> Optional[str]:
+    if distribution is None:
+        return None
+
+    direct_url = _read_direct_url(distribution)
+    if direct_url is None:
+        return None
+
+    vcs_info = direct_url.get("vcs_info")
+    if not isinstance(vcs_info, dict):
+        return None
+
+    commit_id = vcs_info.get("commit_id")
+    if isinstance(commit_id, str) and commit_id:
+        return commit_id
+
+    return None
+
+
+def _read_direct_url(
+    distribution: importlib.metadata.Distribution,
+) -> Optional[Dict[str, Any]]:
+    direct_url_text = distribution.read_text("direct_url.json")
+    if direct_url_text is None:
+        return None
+
+    try:
+        direct_url = json.loads(direct_url_text)
+    except json.JSONDecodeError:
+        return None
+
+    if isinstance(direct_url, dict):
+        return direct_url
+
+    return None
+
+
+def _get_local_git_sha() -> Optional[str]:
+    git_root = _find_git_root(_PACKAGE_DIR)
+    if git_root is None:
+        return None
+
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(git_root), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+    git_sha = result.stdout.strip()
+    return git_sha or None
+
+
+def _get_source_path() -> Optional[str]:
+    git_root = _find_git_root(_PACKAGE_DIR)
+    if git_root is None:
+        return None
+
+    return str(_PACKAGE_DIR)
+
+
+def _find_git_root(start: Path) -> Optional[Path]:
+    for path in (start, *start.parents):
+        if (path / ".git").exists():
+            return path
+
+    return None

--- a/policyengine_core/build_metadata.py
+++ b/policyengine_core/build_metadata.py
@@ -18,10 +18,10 @@ def get_runtime_metadata() -> Dict[str, Any]:
     available in release or integration-test workflows.
     """
 
-    distribution = _get_distribution()
+    distribution = importlib.metadata.distribution(PACKAGE_NAME)
     metadata: Dict[str, Any] = {
         "name": PACKAGE_NAME,
-        "version": _get_package_version(distribution),
+        "version": distribution.version,
     }
 
     git_sha = _get_direct_url_git_sha(distribution)
@@ -31,28 +31,9 @@ def get_runtime_metadata() -> Dict[str, Any]:
     return metadata
 
 
-def _get_distribution() -> Optional[importlib.metadata.Distribution]:
-    try:
-        return importlib.metadata.distribution(PACKAGE_NAME)
-    except importlib.metadata.PackageNotFoundError:
-        return None
-
-
-def _get_package_version(
-    distribution: Optional[importlib.metadata.Distribution],
-) -> str:
-    if distribution is not None:
-        return distribution.version
-
-    raise importlib.metadata.PackageNotFoundError(PACKAGE_NAME)
-
-
 def _get_direct_url_git_sha(
-    distribution: Optional[importlib.metadata.Distribution],
+    distribution: importlib.metadata.Distribution,
 ) -> Optional[str]:
-    if distribution is None:
-        return None
-
     direct_url = _read_direct_url(distribution)
     if direct_url is None:
         return None

--- a/policyengine_core/build_metadata.py
+++ b/policyengine_core/build_metadata.py
@@ -2,13 +2,10 @@ from __future__ import annotations
 
 import importlib.metadata
 import json
-import subprocess
-from pathlib import Path
 from typing import Any, Dict, Optional
 
 
 PACKAGE_NAME = "policyengine-core"
-_PACKAGE_DIR = Path(__file__).resolve().parent
 
 __all__ = ["get_runtime_metadata"]
 
@@ -27,13 +24,9 @@ def get_runtime_metadata() -> Dict[str, Any]:
         "version": _get_package_version(distribution),
     }
 
-    git_sha = _get_direct_url_git_sha(distribution) or _get_local_git_sha()
+    git_sha = _get_direct_url_git_sha(distribution)
     if git_sha is not None:
         metadata["git_sha"] = git_sha
-
-    source_path = _get_source_path()
-    if source_path is not None:
-        metadata["source_path"] = source_path
 
     return metadata
 
@@ -51,28 +44,7 @@ def _get_package_version(
     if distribution is not None:
         return distribution.version
 
-    version = _get_pyproject_version()
-    if version is not None:
-        return version
-
     raise importlib.metadata.PackageNotFoundError(PACKAGE_NAME)
-
-
-def _get_pyproject_version() -> Optional[str]:
-    git_root = _find_git_root(_PACKAGE_DIR)
-    if git_root is None:
-        return None
-
-    pyproject_path = git_root / "pyproject.toml"
-    if not pyproject_path.exists():
-        return None
-
-    for line in pyproject_path.read_text().splitlines():
-        stripped = line.strip()
-        if stripped.startswith("version = "):
-            return stripped.split("=", 1)[1].strip().strip('"')
-
-    return None
 
 
 def _get_direct_url_git_sha(
@@ -110,40 +82,5 @@ def _read_direct_url(
 
     if isinstance(direct_url, dict):
         return direct_url
-
-    return None
-
-
-def _get_local_git_sha() -> Optional[str]:
-    git_root = _find_git_root(_PACKAGE_DIR)
-    if git_root is None:
-        return None
-
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(git_root), "rev-parse", "HEAD"],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-    except (OSError, subprocess.CalledProcessError):
-        return None
-
-    git_sha = result.stdout.strip()
-    return git_sha or None
-
-
-def _get_source_path() -> Optional[str]:
-    git_root = _find_git_root(_PACKAGE_DIR)
-    if git_root is None:
-        return None
-
-    return str(_PACKAGE_DIR)
-
-
-def _find_git_root(start: Path) -> Optional[Path]:
-    for path in (start, *start.parents):
-        if (path / ".git").exists():
-            return path
 
     return None

--- a/tests/core/test_build_metadata.py
+++ b/tests/core/test_build_metadata.py
@@ -6,6 +6,7 @@ import json
 import pytest
 
 from policyengine_core import get_runtime_metadata
+from policyengine_core import build_metadata
 
 
 def test_runtime_metadata_has_core_identity():
@@ -17,6 +18,36 @@ def test_runtime_metadata_has_core_identity():
 
 def test_runtime_metadata_is_json_compatible():
     json.dumps(get_runtime_metadata())
+
+
+def test_runtime_metadata_does_not_include_local_source_path():
+    assert "source_path" not in get_runtime_metadata()
+
+
+def test_runtime_metadata_uses_pep_610_vcs_commit(monkeypatch):
+    class Distribution:
+        version = "1.2.3"
+
+        def read_text(self, name):
+            if name == "direct_url.json":
+                return json.dumps(
+                    {
+                        "vcs_info": {
+                            "vcs": "git",
+                            "commit_id": "abc123",
+                        }
+                    }
+                )
+
+            return None
+
+    monkeypatch.setattr(build_metadata, "_get_distribution", Distribution)
+
+    assert get_runtime_metadata() == {
+        "name": "policyengine-core",
+        "version": "1.2.3",
+        "git_sha": "abc123",
+    }
 
 
 def test_runtime_metadata_uses_bundle_contract_when_available():

--- a/tests/core/test_build_metadata.py
+++ b/tests/core/test_build_metadata.py
@@ -41,7 +41,11 @@ def test_runtime_metadata_uses_pep_610_vcs_commit(monkeypatch):
 
             return None
 
-    monkeypatch.setattr(build_metadata, "_get_distribution", Distribution)
+    monkeypatch.setattr(
+        build_metadata.importlib.metadata,
+        "distribution",
+        lambda name: Distribution(),
+    )
 
     assert get_runtime_metadata() == {
         "name": "policyengine-core",

--- a/tests/core/test_build_metadata.py
+++ b/tests/core/test_build_metadata.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import importlib.metadata
+import json
+
+import pytest
+
+from policyengine_core import get_runtime_metadata
+
+
+def test_runtime_metadata_has_core_identity():
+    metadata = get_runtime_metadata()
+
+    assert metadata["name"] == "policyengine-core"
+    assert metadata["version"] == importlib.metadata.version("policyengine-core")
+
+
+def test_runtime_metadata_is_json_compatible():
+    json.dumps(get_runtime_metadata())
+
+
+def test_runtime_metadata_uses_bundle_contract_when_available():
+    validation = pytest.importorskip("policyengine_bundles")
+
+    validation.load_component_metadata(get_runtime_metadata())


### PR DESCRIPTION
Fixes #485

## Summary

Adds a dependency-free runtime metadata emitter for `policyengine-core` so bundle tooling can identify the core runtime participating in a certified PolicyEngine bundle.

The new public API is:

```python
from policyengine_core import get_runtime_metadata
```

It returns a JSON-compatible dictionary with installed package identity and, when available from installed PEP 610 direct URL metadata, VCS source identity:

```json
{
  "name": "policyengine-core",
  "version": "3.25.4",
  "git_sha": "..."
}
```

## Design notes

- Keeps `policyengine-core` independent from `policyengine-bundles` at runtime.
- Allows `policyengine-bundles` to own and validate the canonical schema.
- Uses installed package metadata for the version.
- Uses PEP 610 `direct_url.json` for VCS commit identity when available.
- Avoids local checkout Git inspection and absolute source paths so bundle metadata does not mix installed package identity with machine-local diagnostics.
- Adds a dedicated PR CI job that installs `policyengine-bundles` test-only and validates the emitted payload against the bundle contract.
- Pins the test-only `policyengine-bundles` Git dependency until that repo has published releases suitable for ordinary dependency specifiers.

## Tests

- `.venv/bin/python -m pytest tests/core/test_build_metadata.py`
- `uv run --frozen --with /Users/administrator/Documents/PolicyEngine/policyengine-bundles python -m pytest tests/core/test_build_metadata.py`
- `uv run --frozen ruff check policyengine_core/build_metadata.py policyengine_core/__init__.py tests/core/test_build_metadata.py`
- `uv run --frozen ruff format --check policyengine_core/build_metadata.py policyengine_core/__init__.py tests/core/test_build_metadata.py`