### PR TITLE
Avoid macro cache initialization when reads are disabled

### DIFF
--- a/changelog.d/lazy-macro-cache.fixed.md
+++ b/changelog.d/lazy-macro-cache.fixed.md
@@ -1,0 +1,1 @@
+Avoid constructing macro-cache metadata during calculations when macro-cache reads are disabled.

--- a/policyengine_core/simulations/simulation.py
+++ b/policyengine_core/simulations/simulation.py
@@ -707,11 +707,10 @@ class Simulation:
         if cached_array is not None:
             return cached_array
 
-        smc = SimulationMacroCache(self.tax_benefit_system)
-
         # Check if cache can be used, if available, check if path exists
         is_cache_available = self.check_macro_cache(variable_name, str(period))
         if is_cache_available:
+            smc = SimulationMacroCache(self.tax_benefit_system)
             smc.set_cache_path(
                 self.dataset.file_path.parent,
                 self.dataset.name,

--- a/tests/core/test_simulations.py
+++ b/tests/core/test_simulations.py
@@ -1,5 +1,6 @@
 from policyengine_core.country_template.situation_examples import single
 from policyengine_core.simulations import SimulationBuilder
+import policyengine_core.simulations.simulation as simulation_module
 from policyengine_core.simulations.simulation_macro_cache import (
     SimulationMacroCache,
 )
@@ -90,3 +91,24 @@ def test_macro_cache(tax_benefit_system):
     )
     cache.clear_cache(cache.cache_folder_path)
     assert not cache.cache_folder_path.exists()
+
+
+def test_calculate_without_macro_cache_does_not_build_macro_cache(
+    tax_benefit_system, monkeypatch
+):
+    class UnexpectedSimulationMacroCache:
+        def __init__(self, tax_benefit_system):
+            raise AssertionError(
+                "SimulationMacroCache should not be constructed when "
+                "macro cache reads are disabled"
+            )
+
+    monkeypatch.setattr(
+        simulation_module,
+        "SimulationMacroCache",
+        UnexpectedSimulationMacroCache,
+    )
+
+    simulation = SimulationBuilder().build_default_simulation(tax_benefit_system)
+
+    simulation.calculate("income_tax", "2017-01")


### PR DESCRIPTION
## Summary
- Instantiate `SimulationMacroCache` only after `check_macro_cache` confirms a macro-cache read is available.
- Avoid repeated package metadata lookups for ordinary household simulations where macro-cache reads are disabled.
- Add a regression test that default calculations do not construct the macro cache.

## Context
This surfaced while investigating elevated household API latency on requests that include Medicaid outputs. The broader Medicaid calculation graph comes from [PolicyEngine/policyengine-us#8169](https://github.com/PolicyEngine/policyengine-us/pull/8169), which fixed MAGI Medicaid household construction by moving from a tax-unit proxy to person-specific tax-filer and non-filer rules.

That policyengine-us change is valid model behavior, but it expands the number of variables calculated for Medicaid. In household simulations, macro-cache reads are normally unavailable, yet `Simulation._calculate` was still constructing `SimulationMacroCache` before checking availability. That constructor reads package metadata, so the expanded Medicaid graph turned a small per-variable overhead into a noticeable latency regression.

In a local reproduction using the current household API stack and a partner-style payload with Medicaid among requested outputs, warm `/us/calculate` endpoint timing was about 2.5s on current core and about 0.36-0.64s with this patch. The change preserves the existing macro-cache read path when a cache is actually available.

## Testing
- `uv run pytest tests/core/test_simulations.py::test_calculate_without_macro_cache_does_not_build_macro_cache tests/core/test_simulations.py::test_macro_cache -q`
- `uv run ruff check policyengine_core/simulations/simulation.py tests/core/test_simulations.py`
