### PR TITLE
Remove policyengine-bundles contract CI

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -25,25 +25,6 @@ jobs:
             echo "Types: added, changed, fixed, removed, breaking"
             exit 1
           fi
-  BundleMetadataContract:
-    name: Validate bundle metadata contract
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.14"
-      - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
-      - name: Install core
-        run: uv pip install --system .
-      - name: Install bundle validation tooling
-        # Pin the test-only bundle contract dependency until policyengine-bundles
-        # has published releases suitable for ordinary dependency specifiers.
-        run: uv pip install --system "policyengine-bundles @ git+https://github.com/PolicyEngine/policyengine-bundles@8ae9f56fefcf89f69b8a7e3bc49928509c6207be"
-      - name: Validate runtime metadata contract
-        run: python -m pytest tests/core/test_build_metadata.py
   Test:
     strategy:
       matrix:

--- a/changelog.d/remove-bundle-contract-ci.removed.md
+++ b/changelog.d/remove-bundle-contract-ci.removed.md
@@ -1,0 +1,1 @@
+Removed the policyengine-bundles metadata contract check from core pull-request CI.

--- a/tests/core/test_build_metadata.py
+++ b/tests/core/test_build_metadata.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import importlib.metadata
 import json
 
-import pytest
-
 from policyengine_core import get_runtime_metadata
 from policyengine_core import build_metadata
 
@@ -52,9 +50,3 @@ def test_runtime_metadata_uses_pep_610_vcs_commit(monkeypatch):
         "version": "1.2.3",
         "git_sha": "abc123",
     }
-
-
-def test_runtime_metadata_uses_bundle_contract_when_available():
-    validation = pytest.importorskip("policyengine_bundles")
-
-    validation.load_component_metadata(get_runtime_metadata())


### PR DESCRIPTION
Fixes #503

## Summary

- Remove the PR job that installed `policyengine-bundles` only to validate bundle metadata contracts.
- Remove the corresponding test-only import of `policyengine_bundles` from core build metadata tests.
- Keep core metadata tests focused on `policyengine-core` runtime/build metadata; certified bundle verification now belongs to `policyengine.py`.

## Validation

- Not run locally; this is a narrow CI/test cleanup and no runtime code changed.