### PR TITLE
Document YAML unit-test format and portability notes

### DIFF
--- a/.github/workflows/fork-ci.yaml
+++ b/.github/workflows/fork-ci.yaml
@@ -3,7 +3,7 @@ name: Fork CI
 on:
   pull_request:
     branches: [master]
-  workflow_dispatch:
+  workflow_dispatch: {}
 
 permissions:
   contents: read

--- a/.github/workflows/fork-ci.yaml
+++ b/.github/workflows/fork-ci.yaml
@@ -1,0 +1,38 @@
+name: Fork CI
+
+on:
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fork-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+      - name: Install package and development dependencies
+        run: make install
+      - name: Check formatting
+        run: uv run ruff format --check .
+      - name: Check lint
+        run: uv run ruff check .
+      - name: Run tests
+        run: make test
+      - name: Build package
+        run: make build
+      - name: Build documentation
+        run: make documentation

--- a/changelog.d/fork-local-ci.changed.md
+++ b/changelog.d/fork-local-ci.changed.md
@@ -1,0 +1,1 @@
+Added fork-local pull-request and manually dispatched CI validation.

--- a/changelog.d/yaml-test-docs.changed.md
+++ b/changelog.d/yaml-test-docs.changed.md
@@ -1,0 +1,1 @@
+Documented the PolicyEngine YAML unit-test shape and portability guidance for external converters.

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -13,6 +13,7 @@ parts:
     - file: usage/datasets
     - file: usage/reforms
     - file: usage/charts
+    - file: usage/yaml_tests
   - caption: Python API
     chapters:
     - file: python_api/commons

--- a/docs/usage/yaml_tests.md
+++ b/docs/usage/yaml_tests.md
@@ -31,8 +31,10 @@ Accepted top-level fields:
 - **Entity inputs**: nest under the entity plural, then instance id, then
   variable name (the same shape `SimulationBuilder.build_from_dict` accepts).
 - **Dotted input keys**: treated as **inline parameter reforms** via
-  `set_parameter`, not as person/household variables. This differs from
-  OpenFisca Core, which uses an explicit `parameters` field.
+  `set_parameter` (see `policyengine_core/tools/test_runner.py`, which imports
+  `set_parameter` and assembles `inline_reforms` while parsing `input`), not as
+  person/household variables. This differs from OpenFisca Core, which uses an
+  explicit `parameters` field.
 - **Outputs**: may be direct variable names, entity singular keys, or entity
   plural → instance id → variable paths.
 

--- a/docs/usage/yaml_tests.md
+++ b/docs/usage/yaml_tests.md
@@ -1,0 +1,67 @@
+# YAML unit tests
+
+PolicyEngine country packages express most unit tests as YAML files executed by
+`policyengine_core.tools.test_runner.run_tests` (or the
+`policyengine-core test` CLI).
+
+## Document shape
+
+A file may contain either a single mapping or a list of mappings. Each mapping
+is one test case. Unknown top-level keys are rejected.
+
+Accepted top-level fields:
+
+| Field | Role |
+| --- | --- |
+| `name` | Optional human-readable test name |
+| `description` | Optional longer description |
+| `period` | Default simulation period for the case |
+| `input` | Input values (scalars or nested entity maps) |
+| `output` | Expected values (required at runtime) |
+| `absolute_error_margin` | Absolute tolerance passed to `assert_near` |
+| `relative_error_margin` | Relative tolerance passed to `assert_near` |
+| `reforms` | Reform module path(s) to apply before running |
+| `extensions` | Extension module path(s) to load |
+| `keywords` | Tags used with name filters |
+| `only_variables` / `ignore_variables` | Variable filters for the runner |
+
+## Input and output conventions
+
+- **Scalar inputs**: top-level `input` keys are variable names.
+- **Entity inputs**: nest under the entity plural, then instance id, then
+  variable name (the same shape `SimulationBuilder.build_from_dict` accepts).
+- **Dotted input keys**: treated as **inline parameter reforms** via
+  `set_parameter`, not as person/household variables. This differs from
+  OpenFisca Core, which uses an explicit `parameters` field.
+- **Outputs**: may be direct variable names, entity singular keys, or entity
+  plural → instance id → variable paths.
+
+Example:
+
+```yaml
+- name: Basic income example
+  period: 2023
+  absolute_error_margin: 0.01
+  input:
+    age: 30
+    employment_income: 10000
+  output:
+    income_tax: 0
+```
+
+## Portability notes
+
+PolicyEngine's YAML format is the source of truth for in-repo validation. When
+exporting or comparing tests with other engines:
+
+1. Prefer a **documented subset** (scalar or simple nested entity maps, absolute
+   margins only).
+2. **Reject loudly** constructs that are engine-specific or ambiguous in a
+   portable intermediate form: `reforms`, `extensions`, relative margins, dotted
+   parameter overrides, expression strings, and nulls.
+3. Keep intermediate interchange formats **outside** this repository unless a
+   maintainer-approved use case needs them in-tree. External converters should
+   pin the `policyengine-core` commit they verified against `test_runner.py`.
+
+These rules keep native tests cheap to write while making cross-engine migration
+tools deterministic rather than lossy.


### PR DESCRIPTION
## What's changed

Closes #514.

Documents the YAML unit-test shape accepted by `policyengine_core.tools.test_runner`, including dotted-input parameter reform behavior and portability guidance for deterministic external converters. Native PolicyEngine YAML remains the in-repository source of truth; no converter or runtime dependency is added to core.

## Verification

- [x] Documentation page added to the table of contents.
- [x] Changelog fragment added.
- [x] Examples and rejection guidance are grounded in the current loader behavior.
- [ ] `make format && make documentation` awaits the upstream workflow run.
- [x] Issue linked and project item updated.

## Compatibility and limits

Documentation-only. The external prototype supports a deliberately restricted subset and rejects reforms, extensions, relative margins, lists, nulls, and expressions that cannot be translated without loss.

## Maintainer action required

Please approve the first-time-contributor documentation workflow and confirm whether this format guidance belongs in core documentation.