### PR TITLE
Purge the full visibility chain in Simulation.delete_arrays and give clones private disk views

### DIFF
--- a/changelog.d/branch-scoped-delete-arrays.fixed.md
+++ b/changelog.d/branch-scoped-delete-arrays.fixed.md
@@ -1,0 +1,1 @@
+Fixed nested simulation cache deletion so perturbation branches recompute inherited values without mutating parent storage.

--- a/policyengine_core/data_storage/on_disk_storage.py
+++ b/policyengine_core/data_storage/on_disk_storage.py
@@ -26,6 +26,26 @@ class OnDiskStorage:
         self.preserve_storage_dir = preserve_storage_dir
         self.storage_dir = storage_dir
 
+    def clone(self) -> "OnDiskStorage":
+        """Create a private metadata view over this storage directory.
+
+        The file and enum mappings are copied so deleting or rewiring entries
+        through the clone does not mutate the source storage. The underlying
+        ``.npy`` files remain shared: writing the same ``{branch}_{period}``
+        key from two views targets the same path and can overwrite the file.
+        Clones retain the original cleanup owner so the shared directory stays
+        alive, but never own cleanup themselves.
+        """
+        clone = OnDiskStorage(
+            self.storage_dir,
+            is_eternal=self.is_eternal,
+            preserve_storage_dir=True,
+        )
+        clone._files = self._files.copy()
+        clone._enums = self._enums.copy()
+        clone._storage_dir_owner = getattr(self, "_storage_dir_owner", self)
+        return clone
+
     def _decode_file(self, file: str) -> ArrayLike:
         enum = self._enums.get(file)
         if enum is not None:

--- a/policyengine_core/holders/holder.py
+++ b/policyengine_core/holders/holder.py
@@ -57,10 +57,14 @@ class Holder:
                 "formula",
                 "simulation",
                 "_memory_storage",
+                "_disk_storage",
             ):
                 new_dict[key] = value
 
         new._memory_storage = self._memory_storage.clone()
+        new._disk_storage = (
+            self._disk_storage.clone() if self._disk_storage is not None else None
+        )
 
         new_dict["population"] = population
         new_dict["simulation"] = population.simulation

--- a/policyengine_core/simulations/simulation.py
+++ b/policyengine_core/simulations/simulation.py
@@ -1261,10 +1261,14 @@ class Simulation:
 
     def delete_arrays(self, variable: str, period: Period = None) -> None:
         """
-        Delete a variable's value for a given period
+        Delete a variable's values visible to this simulation branch.
 
-        :param variable: the variable to be set
-        :param period: the period for which the value should be deleted
+        The calling branch, each ancestor branch, and the default branch are
+        purged from this simulation's private holder storage. Other branch
+        names and the parent simulation's holder storage remain unchanged.
+
+        :param variable: the variable whose cached values should be deleted
+        :param period: the period to delete, or all periods when omitted
 
         Example:
 
@@ -1286,7 +1290,9 @@ class Simulation:
         >>> simulation.get_array('age', '2018-05') is None
         True
         """
-        self.get_holder(variable).delete_arrays(period)
+        holder = self.get_holder(variable)
+        for branch_name in self._get_visible_branch_names():
+            holder.delete_arrays(period, branch_name)
         _fast_cache = getattr(self, "_fast_cache", None)
         if period is None:
             if _fast_cache is not None:
@@ -1631,7 +1637,7 @@ class Simulation:
         return variable is not None and variable.is_input_variable()
 
     def _get_visible_branch_names(self) -> List[str]:
-        branch_names = [self.branch_name]
+        branch_names = [getattr(self, "branch_name", "default")]
         parent = getattr(self, "parent_branch", None)
         while parent is not None:
             branch_names.append(parent.branch_name)

--- a/tests/core/test_branch_scoped_delete_arrays.py
+++ b/tests/core/test_branch_scoped_delete_arrays.py
@@ -1,0 +1,176 @@
+"""Regression tests for deleting caches from nested simulation branches."""
+
+from __future__ import annotations
+
+import gc
+
+import numpy as np
+
+from policyengine_core.country_template import CountryTaxBenefitSystem
+from policyengine_core.data_storage import OnDiskStorage
+from policyengine_core.simulations import SimulationBuilder
+
+
+PERIOD = "2017-01"
+
+
+def _salary_simulation():
+    return SimulationBuilder().build_from_entities(
+        CountryTaxBenefitSystem(),
+        {
+            "persons": {"bill": {"salary": {PERIOD: 3_000}}},
+            "households": {"household": {"parents": ["bill"]}},
+        },
+    )
+
+
+def _purge_formula_outputs(simulation):
+    for variable_name in simulation.tax_benefit_system.variables:
+        if variable_name not in simulation.input_variables:
+            simulation.delete_arrays(variable_name)
+
+
+def test_nested_branch_recomputes_after_formula_output_purge():
+    """A perturbed nested branch must not reuse its parent's formula output."""
+    simulation = _salary_simulation()
+    measurement = simulation.get_branch("measurement")
+    parent_value = measurement.calculate("income_tax", PERIOD).copy()
+    perturbed = measurement.get_branch("perturbed")
+
+    _purge_formula_outputs(perturbed)
+    perturbed.set_input("salary", PERIOD, np.asarray([6_000.0]))
+    recomputed_value = perturbed.calculate("income_tax", PERIOD)
+
+    np.testing.assert_allclose(parent_value, [450.0], rtol=1e-6)
+    np.testing.assert_allclose(recomputed_value, [900.0], rtol=1e-6)
+    np.testing.assert_allclose(
+        measurement.calculate("income_tax", PERIOD),
+        parent_value,
+    )
+
+
+def test_delete_arrays_purges_only_visible_branch_names():
+    """Root and nested purges must preserve unrelated dispatched values."""
+    simulation = _salary_simulation()
+    root_holder = simulation.get_holder("salary")
+    dispatched_value = np.asarray([7_777.0])
+    root_holder._memory_storage.put(dispatched_value, PERIOD, "dispatched")
+
+    simulation.delete_arrays("salary", PERIOD)
+
+    assert root_holder._memory_storage.get(PERIOD, "default") is None
+    np.testing.assert_array_equal(
+        root_holder._memory_storage.get(PERIOD, "dispatched"),
+        dispatched_value,
+    )
+
+    measurement = simulation.get_branch("measurement")
+    perturbed = measurement.get_branch("perturbed")
+    child_holder = perturbed.get_holder("salary")
+    child_holder._memory_storage.put(np.asarray([1.0]), PERIOD, "default")
+    child_holder._memory_storage.put(np.asarray([2.0]), PERIOD, "measurement")
+    child_holder._memory_storage.put(np.asarray([3.0]), PERIOD, "perturbed")
+
+    perturbed.delete_arrays("salary", PERIOD)
+
+    assert child_holder._memory_storage.get(PERIOD, "default") is None
+    assert child_holder._memory_storage.get(PERIOD, "measurement") is None
+    assert child_holder._memory_storage.get(PERIOD, "perturbed") is None
+    np.testing.assert_array_equal(
+        child_holder._memory_storage.get(PERIOD, "dispatched"),
+        dispatched_value,
+    )
+
+
+def test_on_disk_storage_clone_copies_metadata_without_owning_directory(tmp_path):
+    """A cloned disk view must own metadata, but not the shared directory."""
+    storage_dir = tmp_path / "storage"
+    storage_dir.mkdir()
+    storage = OnDiskStorage(str(storage_dir), is_eternal=True)
+    storage.put(np.asarray([12.0]), PERIOD, "default")
+    storage._enums["sentinel"] = "enum"
+
+    try:
+        assert storage.preserve_storage_dir is False
+        clone = storage.clone()
+
+        assert clone is not storage
+        assert clone.storage_dir == storage.storage_dir
+        assert clone.is_eternal == storage.is_eternal
+        assert clone.preserve_storage_dir is True
+        assert clone._files == storage._files
+        assert clone._files is not storage._files
+        assert clone._enums == storage._enums
+        assert clone._enums is not storage._enums
+        assert clone._storage_dir_owner is storage
+        assert clone.clone()._storage_dir_owner is storage
+    finally:
+        # Let pytest's tmp_path cleanup remove the directory even if an
+        # assertion fails before the clone can prove its ownership setting.
+        storage.preserve_storage_dir = True
+
+
+def test_on_disk_storage_clone_keeps_cleanup_owner_alive(tmp_path):
+    """A detached clone must remain readable after its source is released."""
+    storage_dir = tmp_path / "storage"
+    storage_dir.mkdir()
+    storage = OnDiskStorage(str(storage_dir))
+    storage.put(np.asarray([12.0]), PERIOD, "default")
+    clone = storage.clone()
+
+    del storage
+    gc.collect()
+
+    assert storage_dir.is_dir()
+    np.testing.assert_array_equal(clone.get(PERIOD, "default"), [12.0])
+
+
+def test_child_disk_delete_keeps_parent_view_intact(tmp_path):
+    """Deleting through a child must rewire only the child's disk mappings."""
+    simulation = _salary_simulation()
+    parent_holder = simulation.get_holder("salary")
+    parent_holder._memory_storage.delete(PERIOD, "default")
+    parent_holder._disk_storage = parent_holder.create_disk_storage(str(tmp_path))
+    parent_storage = parent_holder._disk_storage
+    parent_storage.put(np.asarray([3_000.0]), PERIOD, "default")
+    disk_key = f"default_{PERIOD}"
+
+    try:
+        child = simulation.get_branch("measurement")
+        child_holder = child.get_holder("salary")
+        child_storage = child_holder._disk_storage
+        assert child_storage._files[disk_key] == parent_storage._files[disk_key]
+        inherited_value = child_holder.get_array(PERIOD, child.branch_name)
+
+        child.delete_arrays("salary", PERIOD)
+
+        assert child_storage is not parent_storage
+        assert child_storage.preserve_storage_dir is True
+        np.testing.assert_array_equal(inherited_value, [3_000.0])
+        assert disk_key in parent_storage._files
+        assert disk_key not in child_storage._files
+        assert (tmp_path / "salary" / f"{disk_key}.npy").is_file()
+        np.testing.assert_array_equal(
+            parent_holder._disk_storage.get(PERIOD, "default"),
+            [3_000.0],
+        )
+    finally:
+        # The path belongs to pytest for this test; avoid a later destructor
+        # racing tmp_path cleanup if the assertion above fails.
+        parent_storage.preserve_storage_dir = True
+
+
+def test_derivative_recomputes_inside_named_branch():
+    """A derivative clone must purge formula outputs visible to its branch."""
+    simulation = _salary_simulation()
+    measurement = simulation.get_branch("measurement")
+    measurement.calculate("income_tax", PERIOD)
+
+    derivative = measurement.derivative(
+        "income_tax",
+        "salary",
+        PERIOD,
+        delta=1,
+    )
+
+    np.testing.assert_allclose(derivative, [0.15], rtol=1e-4, atol=1e-6)

--- a/tests/core/test_fast_cache_guards.py
+++ b/tests/core/test_fast_cache_guards.py
@@ -60,7 +60,7 @@ def test_set_input_without_fast_cache_attribute():
 def test_delete_arrays_without_fast_cache_attribute():
     sim = _bare_simulation()
     sim.get_holder = lambda name: types.SimpleNamespace(
-        delete_arrays=lambda period: None
+        delete_arrays=lambda period, branch_name: None
     )
     # No _fast_cache attribute — must not crash
     sim.delete_arrays("variable", period=None)


### PR DESCRIPTION
Fixes the mechanism behind PolicyEngine/policyengine-us#9086: behavioral-response measurement branches recorded marginal tax rates of exactly 1.0 for every adult in both the baseline and reform branches, making `relative_wage_change ≡ 0` and the substitution channel of labor supply responses (and the capital-gains MTR channel) inert in every behavioral run, while static/root-simulation MTRs stayed correct.

## What was wrong

`Simulation.delete_arrays` called `holder.delete_arrays(period)` with no branch name, so only `default:`-keyed storage was purged. Inside a *named* branch (the behavioral measurement branches), the purge-then-perturb pattern used by `marginal_tax_rate` and friends therefore failed to remove the parent branch's cached `household_net_income` from the sub-branch's cloned storage; `Holder.get_array`'s ancestor walk-up served it back, the perturbed input never fed anything, and `1 − 0/Δ = 1.0` came out for every masked adult. `Simulation.derivative` had the same latent bug.

## Changes

1. **`Simulation.delete_arrays` purges the caller's full visibility chain** — its own branch name, each ancestor via `parent_branch`, and `default` (the existing `_get_visible_branch_names`, deduplicated) — in the simulation's own private storage. At root the chain is just `default`, so root behavior is unchanged. `InMemoryStorage.delete` / `OnDiskStorage.delete` semantics are untouched: sibling and dispatched branch keys survive (the branch-scoped-delete guarantees from the earlier C2 fix and #484 are preserved and now covered by a test).
2. **Cloned holders get a private disk view.** Previously `Holder.clone` deep-copied `_memory_storage` but shared the same `OnDiskStorage` object, so chain deletion through a clone would have mutated the parent's disk mappings. `OnDiskStorage.clone()` copies the `_files`/`_enums` mappings over the same storage directory, never owns directory cleanup, and keeps the original cleanup owner alive through a backreference (clone-of-clone propagates the root owner). The `.npy` files themselves remain shared; identical `{branch}_{period}` writes from two views still target the same path (pre-existing, documented in the docstring). Note `memory_config` defaults to `None` and nothing in core/-us construction enables it, so disk storage is inert in standard runs — this change is for correctness when it is enabled.

## Call-site audit

All 13 simulation-level `delete_arrays` call sites in policyengine-us 1.729.0 (the three MTR formulas, the component-MTR helper, capital-gains responses, the SSA revenue branch calcs, and the NY CTC/EITC retained branches) are purge-for-recompute and want the new semantics; the 11 direct `Holder.delete_arrays` calls (pre-response input migration in `system.py`, `BranchedSimulation` cleanup) keep their existing single-branch behavior. No caller preserves a cached own/ancestor value across a purge.

## Tests and checks run

- 6 new regression tests in `tests/core/test_branch_scoped_delete_arrays.py`: nested-branch recompute-after-purge, visibility-chain scope with sibling/dispatch survival, `OnDiskStorage.clone` metadata/ownership, cleanup-owner GC lifetime, child disk-delete parent-safety, and `derivative()` inside a named branch. All 6 fail on unfixed master and pass with this change (verified by reverting `policyengine_core/` to master and rerunning).
- Full suite: 680 passed, 4 skipped, 1 xfailed; country-template runner 39 passed; `make format` clean.
- End-to-end against policyengine-us 1.729.0 (this branch installed editable): the #9086 repro now records measurement MTRs equal to the statics (0.1965 baseline / 0.2765 reform) and `relative_wage_change` −0.0996, where master records 1.0000/1.0000/0.0000.
- Towncrier fragment: `changelog.d/branch-scoped-delete-arrays.fixed.md`.

## Observed while auditing, intentionally not addressed here

- `purge_cache_of_invalid_values` and policyengine-us `BranchedSimulation` cleanup still delete `default` only for named simulations (pre-existing).
- `OnDiskStorage.delete` removes only the exact `{branch}_{period}` mapping for a containing period (memory backend removes contained subperiods) and does not prune `_enums`.
- `subsample()` rebuilds the baseline branch from `self.clone()` (reform system) and assigns the saved baseline system to `self.branches["tax_benefit_system"]` — a dict key, not the branch; reproduced on the country template and will be filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
