### PR TITLE
Reject misplaced uprating rounding metadata

### DIFF
--- a/changelog.d/reject-misplaced-uprating-rounding.fixed.md
+++ b/changelog.d/reject-misplaced-uprating-rounding.fixed.md
@@ -1,0 +1,1 @@
+Parameter loading now rejects uprating rounding rules placed where they would be silently ignored.

--- a/policyengine_core/parameters/helpers.py
+++ b/policyengine_core/parameters/helpers.py
@@ -90,8 +90,25 @@ def _validate_parameter(parameter, data, data_type=None, allowed_keys=None):
             parameter.file_path,
         )
 
+    if isinstance(data, dict):
+        _validate_uprating_rounding_metadata(parameter, data.get("metadata"))
+
     if allowed_keys is not None and isinstance(data, dict):
         _warn_on_unknown_keys(parameter, data, allowed_keys)
+
+
+def _validate_uprating_rounding_metadata(parameter, metadata):
+    if not isinstance(metadata, dict):
+        return
+    if "uprating" not in metadata or "rounding" not in metadata:
+        return
+
+    raise ParameterParsingError(
+        "Invalid uprating metadata for '{}': `rounding` must be nested inside "
+        "`uprating`; placing both keys at the same level causes the rounding "
+        "rule to be ignored.".format(parameter.name),
+        parameter.file_path,
+    )
 
 
 def _warn_on_unknown_keys(parameter, data, allowed_keys):

--- a/tests/core/parameters/operations/test_uprating.py
+++ b/tests/core/parameters/operations/test_uprating.py
@@ -344,6 +344,62 @@ def test_parameter_uprating_with_rounding():
     assert interpolated.to_be_uprated("2018-01-01") == 4
 
 
+@pytest.mark.parametrize(
+    "data",
+    [
+        {
+            "parameter": {
+                "values": {"2025-01-01": 1},
+                "metadata": {
+                    "uprating": "uprater",
+                    "rounding": {"interval": 1, "type": "upwards"},
+                },
+            },
+        },
+        {
+            "scale": {
+                "metadata": {
+                    "uprating": "uprater",
+                    "rounding": {"interval": 1, "type": "upwards"},
+                },
+                "brackets": [
+                    {
+                        "threshold": {"2025-01-01": 0},
+                        "rate": {"2025-01-01": 0.1},
+                    },
+                ],
+            },
+        },
+        {
+            "scale": {
+                "brackets": [
+                    {
+                        "threshold": {"2025-01-01": 0},
+                        "rate": {"2025-01-01": 0.1},
+                        "metadata": {
+                            "uprating": "uprater",
+                            "rounding": {
+                                "interval": 1,
+                                "type": "upwards",
+                            },
+                        },
+                    },
+                ],
+            },
+        },
+    ],
+)
+def test_parameter_uprating_rejects_rounding_beside_uprating(data):
+    from policyengine_core.errors import ParameterParsingError
+    from policyengine_core.parameters import ParameterNode
+
+    with pytest.raises(
+        ParameterParsingError,
+        match="`rounding` must be nested inside `uprating`",
+    ):
+        ParameterNode(data=data)
+
+
 def test_parameter_uprating_with_self():
     from policyengine_core.parameters import ParameterNode
 


### PR DESCRIPTION
Fixes #216

> Merge order: PolicyEngine/policyengine-us#9371 must merge before this pull request. Current PolicyEngine US `main` contains 176 definitions that this validation will reject.

## Summary

- reject metadata that places `rounding` and `uprating` at the same level
- report that `rounding` must be nested inside `uprating` because the previous structure is ignored
- validate ordinary parameters, scale-level metadata, and bracket-level metadata through the common parameter schema check
- retain the existing supported nested rounding behavior

## Validation

- `uv run --frozen pytest tests/core/parameters -v` — 49 passed
- `uv run --frozen ruff format .` — 270 files unchanged
- `uv run --frozen ruff check .` — all checks passed
- loaded the corrected PolicyEngine US parameter tree through this validation — 75,480 parameter descendants loaded

The full Core test suite was not run locally; the complete parameter suite covering this loader behavior passed. `make format` could not locate `ruff` on the shell path, so the same configured formatter and lint checks were run through the repository's `uv` environment.
