### PR TITLE
Document the flat-file dataset format

### DIFF
--- a/changelog.d/document-flat-file-data-format.changed.md
+++ b/changelog.d/document-flat-file-data-format.changed.md
@@ -1,0 +1,1 @@
+Documented the `Dataset.FLAT_FILE` option alongside the other `Dataset.data_format` values.

--- a/policyengine_core/data/dataset.py
+++ b/policyengine_core/data/dataset.py
@@ -58,7 +58,7 @@ class Dataset:
     label: str = None
     """The label of the dataset. This is used for logging and is used as the key in the `datasets` dictionary."""
     data_format: str = None
-    """The format of the dataset. This can be either `Dataset.ARRAYS`, `Dataset.TIME_PERIOD_ARRAYS` or `Dataset.TABLES`. If `Dataset.ARRAYS`, the dataset is stored as a collection of arrays. If `Dataset.TIME_PERIOD_ARRAYS`, the dataset is stored as a collection of arrays, with one array per time period. If `Dataset.TABLES`, the dataset is stored as a collection of tables (DataFrames)."""
+    """The format of the dataset. This can be either `Dataset.ARRAYS`, `Dataset.TIME_PERIOD_ARRAYS`, `Dataset.TABLES` or `Dataset.FLAT_FILE`. If `Dataset.ARRAYS`, the dataset is stored as a collection of arrays. If `Dataset.TIME_PERIOD_ARRAYS`, the dataset is stored as a collection of arrays, with one array per time period. If `Dataset.TABLES`, the dataset is stored as a collection of tables (DataFrames). If `Dataset.FLAT_FILE`, the dataset is stored as a single CSV file (DataFrame)."""
     file_path: Path = None
     """The path to the dataset file. This is used to load the dataset from a file."""
     time_period: str = None


### PR DESCRIPTION
Fixes #263

## Summary

- List `Dataset.FLAT_FILE` alongside the other supported `Dataset.data_format` values.
- Document that this format stores the dataset as a single CSV file represented by a pandas DataFrame.
- Add the required towncrier fragment.

## Validation

- `uv run --no-sync ruff format policyengine_core/data/dataset.py`
- `uv run --no-sync ruff check policyengine_core/data/dataset.py`
- `uv run --no-sync towncrier build --draft --version 3.32.1`
- `uv run --no-sync make documentation` — succeeded with 25 pre-existing warnings
- `git diff --check`

The checks use the existing development environment without synchronizing because the automated 3.32.0 release commit updated the package version while the lockfile's root-package record remains at 3.31.1. This pull request does not alter dependency resolution.

## Documentation review

The `Dataset.data_format` source documentation now describes all four accepted formats. No runtime behavior or separate usage-guide changes are required for this narrowly scoped correction. Impact is low and confidence is high. The generated API page displays the class attributes but, as before, does not render any of their adjacent attribute-description strings; this pull request preserves the documentation pattern requested by the issue rather than changing the documentation configuration.
