### PR TITLE
Send HUGGING_FACE_TOKEN for public but gated Hugging Face repos

### DIFF
--- a/changelog.d/fix-hf-gated-repo-token.fixed.md
+++ b/changelog.d/fix-hf-gated-repo-token.fixed.md
@@ -1,0 +1,1 @@
+Send the HUGGING_FACE_TOKEN when downloading from public but gated Hugging Face repos, not only private ones, so gated dataset downloads no longer fail with a 401 gated-repo error.

--- a/policyengine_core/tools/hugging_face.py
+++ b/policyengine_core/tools/hugging_face.py
@@ -52,6 +52,14 @@ def download_huggingface_dataset(
     """
     Download a dataset from the Hugging Face Hub.
 
+    Private repos and public-but-gated repos both require authentication,
+    so for either the token is resolved by get_or_prompt_hf_token()
+    (HUGGING_FACE_TOKEN, else an interactive prompt when stdin is a TTY,
+    else None) and passed explicitly to hf_hub_download. Public, ungated
+    repos are requested with token=None and never prompt; huggingface_hub
+    may still apply its own implicitly configured token (HF_TOKEN or the
+    login file) in that case.
+
     Args:
         repo (str): The Hugging Face repo name, in format "{org}/{repo}".
         repo_filename (str): The filename of the dataset.
@@ -60,15 +68,23 @@ def download_huggingface_dataset(
     """
     # Attempt connection to Hugging Face model_info endpoint
     # (https://huggingface.co/docs/huggingface_hub/v0.26.5/en/package_reference/hf_api#huggingface_hub.HfApi.model_info)
-    # Attempt to fetch model info to determine if repo is private
+    # Attempt to fetch model info to determine if the repo requires
+    # authentication. Testing `private` alone is not enough: a public but
+    # gated repo still answers model_info() without a token, but the file
+    # download returns 401 unless a gate-approved token is sent.
+    # ModelInfo.gated is False for ungated repos, "auto" or "manual" for
+    # gated repos, and None if the field is absent, so a truthiness test
+    # covers every state (both gate modes need an authenticated request).
     # A RepositoryNotFoundError & 401 likely means the repo is private,
     # but this error will also surface for public repos with malformed URL, etc.
     try:
         fetched_model_info: ModelInfo = model_info(repo)
-        is_repo_private: bool = fetched_model_info.private
+        requires_authentication: bool = bool(fetched_model_info.private) or bool(
+            fetched_model_info.gated
+        )
     except RepositoryNotFoundError as e:
         # If this error type arises, it's likely the repo is private; see docs above
-        is_repo_private = True
+        requires_authentication = True
         pass
     except Exception as e:
         # Otherwise, there probably is just a download error
@@ -77,9 +93,9 @@ def download_huggingface_dataset(
             + f"is private, the URL is malformed, or the dataset does not exist. The full error is {traceback.format_exc()}"
         )
 
-    authentication_token: str = None
-    if is_repo_private:
-        authentication_token: str = get_or_prompt_hf_token()
+    authentication_token: str | None = None
+    if requires_authentication:
+        authentication_token = get_or_prompt_hf_token()
 
     return hf_hub_download(
         repo_id=repo,

--- a/tests/core/tools/test_hugging_face.py
+++ b/tests/core/tools/test_hugging_face.py
@@ -107,6 +107,153 @@ class TestHuggingFaceDownload:
                         )
                         mock_download.assert_not_called()
 
+    @pytest.mark.parametrize("gated", ["manual", "auto"])
+    def test_download_gated_public_repo_passes_env_token(self, gated):
+        """A public but gated repo must receive HUGGING_FACE_TOKEN.
+
+        Regression test for PolicyEngine/policyengine-core#529: `private`
+        is False for a gated repo, but the file download still needs a
+        gate-approved token or the Hub answers 401.
+        """
+        test_repo = "test_repo"
+        test_filename = "test_filename"
+        test_version = "test_version"
+        test_dir = "test_dir"
+        test_token = "gated_repo_test_token"
+
+        with patch.dict(os.environ, {"HUGGING_FACE_TOKEN": test_token}, clear=True):
+            with patch(
+                "policyengine_core.tools.hugging_face.hf_hub_download"
+            ) as mock_download:
+                with patch(
+                    "policyengine_core.tools.hugging_face.model_info"
+                ) as mock_model_info:
+                    mock_model_info.return_value = ModelInfo(
+                        id=test_repo, private=False, gated=gated
+                    )
+
+                    download_huggingface_dataset(
+                        test_repo, test_filename, test_version, test_dir
+                    )
+
+                    mock_download.assert_called_once_with(
+                        repo_id=test_repo,
+                        repo_type="model",
+                        filename=test_filename,
+                        revision=test_version,
+                        token=test_token,
+                        local_dir=test_dir,
+                    )
+
+    def test_download_private_flag_repo_passes_env_token(self):
+        """A repo reported as private=True by model_info still gets the token."""
+        test_repo = "test_repo"
+        test_filename = "test_filename"
+        test_version = "test_version"
+        test_dir = "test_dir"
+        test_token = "private_repo_test_token"
+
+        with patch.dict(os.environ, {"HUGGING_FACE_TOKEN": test_token}, clear=True):
+            with patch(
+                "policyengine_core.tools.hugging_face.hf_hub_download"
+            ) as mock_download:
+                with patch(
+                    "policyengine_core.tools.hugging_face.model_info"
+                ) as mock_model_info:
+                    mock_model_info.return_value = ModelInfo(
+                        id=test_repo, private=True, gated=False
+                    )
+
+                    download_huggingface_dataset(
+                        test_repo, test_filename, test_version, test_dir
+                    )
+
+                    mock_download.assert_called_once_with(
+                        repo_id=test_repo,
+                        repo_type="model",
+                        filename=test_filename,
+                        revision=test_version,
+                        token=test_token,
+                        local_dir=test_dir,
+                    )
+
+    def test_download_gated_repo_non_interactive_without_token(self):
+        """Gated repo in CI without secrets: no prompt, token=None is passed."""
+        test_repo = "test_repo"
+        test_filename = "test_filename"
+        test_version = "test_version"
+        test_dir = "test_dir"
+
+        with patch.dict(os.environ, {}, clear=True):
+            with patch("os.isatty", return_value=False):
+                with patch(
+                    "policyengine_core.tools.hugging_face.getpass"
+                ) as mock_getpass:
+                    with patch(
+                        "policyengine_core.tools.hugging_face.hf_hub_download"
+                    ) as mock_download:
+                        with patch(
+                            "policyengine_core.tools.hugging_face.model_info"
+                        ) as mock_model_info:
+                            mock_model_info.return_value = ModelInfo(
+                                id=test_repo, private=False, gated="manual"
+                            )
+
+                            download_huggingface_dataset(
+                                test_repo, test_filename, test_version, test_dir
+                            )
+
+                            mock_getpass.assert_not_called()
+                            mock_download.assert_called_once_with(
+                                repo_id=test_repo,
+                                repo_type="model",
+                                filename=test_filename,
+                                revision=test_version,
+                                token=None,
+                                local_dir=test_dir,
+                            )
+
+    @pytest.mark.parametrize("gated", [False, None])
+    def test_download_public_ungated_repo_never_prompts(self, gated):
+        """Public, ungated repo: no token lookup and no interactive prompt.
+
+        Guards against widening the predicate so far that every public
+        download on a developer machine asks for a token.
+        """
+        test_repo = "test_repo"
+        test_filename = "test_filename"
+        test_version = "test_version"
+        test_dir = "test_dir"
+
+        with patch.dict(os.environ, {}, clear=True):
+            with patch("os.isatty", return_value=True):
+                with patch(
+                    "policyengine_core.tools.hugging_face.getpass"
+                ) as mock_getpass:
+                    with patch(
+                        "policyengine_core.tools.hugging_face.hf_hub_download"
+                    ) as mock_download:
+                        with patch(
+                            "policyengine_core.tools.hugging_face.model_info"
+                        ) as mock_model_info:
+                            mock_model_info.return_value = ModelInfo(
+                                id=test_repo, private=False, gated=gated
+                            )
+
+                            download_huggingface_dataset(
+                                test_repo, test_filename, test_version, test_dir
+                            )
+
+                            mock_getpass.assert_not_called()
+                            mock_download.assert_called_once_with(
+                                repo_id=test_repo,
+                                repo_type="model",
+                                filename=test_filename,
+                                revision=test_version,
+                                token=None,
+                                local_dir=test_dir,
+                            )
+
 
 class TestGetOrPromptHfToken:
     def test_get_token_from_environment(self):


### PR DESCRIPTION
Fixes #529.

## Summary

`download_huggingface_dataset` decided whether to send a token by testing `ModelInfo.private` only. `policyengine/policyengine-uk-data-private` has been public but gated (`private=False`, `gated="manual"`) since 31 July 2026, so the helper passed `token=None` to `hf_hub_download` and the gate returned `401 GatedRepoError` even when a gate-approved `HUGGING_FACE_TOKEN` was in the environment. The Hub only falls back to its own `HF_TOKEN` variable when no explicit token is passed, which is why PolicyEngine/policyengine-uk#1817 had to export both names as a workaround (see the comment in `.github/workflows/code_changes.yaml` and `pr_code_changes.yaml` there).

## Behaviour change

A repo now requires authentication when `private` is true **or** `gated` is truthy. `ModelInfo.gated` is `False` for ungated repos, `"auto"` or `"manual"` for gated repos, and `None` when the field is absent, so a truthiness test covers every state. In that case the existing `get_or_prompt_hf_token()` supplies the token from `HUGGING_FACE_TOKEN` (or an interactive prompt on a TTY).

Unchanged:

- Public, ungated repos still download with `token=None` and never prompt.
- In a non-interactive environment without secrets, the token is still `None` rather than an empty string (the #422 behaviour), so Dependabot-style CI keeps working for public repos.
- The `RepositoryNotFoundError` path still treats the repo as private.
- On a TTY with `HUGGING_FACE_TOKEN` unset, a gated repo now prompts for a token exactly as a private repo always has. Pressing Enter passes `token=None`, and huggingface_hub then applies its own implicit token (`HF_TOKEN` or the login file) if one is configured.

Verified live: `GET /api/models/policyengine/policyengine-uk-data-private` returns `private: false, gated: "manual"`, and an unauthenticated `HEAD` on a resolve URL returns 401.

## Tests

New tests in `tests/core/tools/test_hugging_face.py`:

- `test_download_gated_public_repo_passes_env_token[manual|auto]` mocks `model_info` returning `private=False, gated=...` and asserts the token read from `HUGGING_FACE_TOKEN` by the real `get_or_prompt_hf_token` reaches `hf_hub_download`. Both fail on `master` and pass here.
- `test_download_private_flag_repo_passes_env_token` covers `private=True` returned by `model_info` (the existing private test only covers the 404 path).
- `test_download_gated_repo_non_interactive_without_token` asserts CI without secrets gets `token=None` and no prompt.
- `test_download_public_ungated_repo_never_prompts[False|None]` guards against widening the predicate into a prompt on every public download.

Checks run locally:

- `uvx ruff format --check .` and `uvx ruff check .` pass; `ruff check --select F821` is clean for the changed files, and mypy on `hugging_face.py` drops from four errors to the one pre-existing `version: str = None` error at line 49.
- `uv run pytest tests`: 702 passed, 4 skipped, 1 xfailed.
- `policyengine-core test policyengine_core/country_template/tests -c policyengine_core.country_template`: 39 passed.

Not run: `make documentation` (no docs changed; CI runs it).

## Related

- Issue: #529
- Incident in policyengine-uk: PolicyEngine/policyengine-uk#1816
- Workaround that this makes unnecessary: PolicyEngine/policyengine-uk#1817
- Earlier token handling: #422

🤖 Generated with [Claude Code](https://claude.com/claude-code)
